### PR TITLE
[SDF-62] Fix Linux compiler flags provided in CMakePresets.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ project(
   LANGUAGES CXX C
   VERSION ${VERSION})
 
-option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(GENERATE_CLANGD_FILE
        "Generate the .clangd file for the host operating system" ON)
+option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
 option(BUILD_GLM "Fetch and build GLM" ON)
 option(BUILD_GLFW "Fetch and build GLFW" ON)
 option(BUILD_TESTING "Fetch GoogleTest and build tests" OFF)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,9 +10,9 @@
       "name": "linux-pedantic",
       "hidden": true,
       "cacheVariables": {
-        "PROJ_CXX_FLAGS": "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS=1 -fstack-protector-strong -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wshadow -Wcast-align -Wunused -Wnull-dereference -Wdouble-promotion -Wimplicit-fallthrough -Wextra-semi -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast",
-        "PROJ_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed,-z,noexecstack,-z,relro,-z,now,-z,nodlopen",
-        "PROJ_SHARED_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed,-z,noexecstack,-z,relro,-z,now,-z,nodlopen"
+        "PROJ_CXX_FLAGS": "-O3;-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=3;-D_GLIBCXX_ASSERTIONS=1;-fstack-protector-strong;-fcf-protection=full;-fstack-clash-protection;-Wall;-Wextra;-Wpedantic;-Wconversion;-Wsign-conversion;-Wcast-qual;-Wformat=2;-Wundef;-Werror=float-equal;-Wshadow;-Wcast-align;-Wunused;-Wnull-dereference;-Wdouble-promotion;-Wimplicit-fallthrough;-Wextra-semi;-Woverloaded-virtual;-Wnon-virtual-dtor;-Wold-style-cast",
+        "PROJ_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;-z,noexecstack;-z,relro;-z,now;-z,nodlopen",
+        "PROJ_SHARED_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;-z,noexecstack;-z,relro;-z,now;-z,nodlopen"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,8 +11,8 @@
       "hidden": true,
       "cacheVariables": {
         "PROJ_CXX_FLAGS": "-O3;-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=3;-D_GLIBCXX_ASSERTIONS=1;-fstack-protector-strong;-fcf-protection=full;-fstack-clash-protection;-Wall;-Wextra;-Wpedantic;-Wconversion;-Wsign-conversion;-Wcast-qual;-Wformat=2;-Wundef;-Werror=float-equal;-Wshadow;-Wcast-align;-Wunused;-Wnull-dereference;-Wdouble-promotion;-Wimplicit-fallthrough;-Wextra-semi;-Woverloaded-virtual;-Wnon-virtual-dtor;-Wold-style-cast",
-        "PROJ_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;-z noexecstack;-z relro;-z now;-z nodlopen",
-        "PROJ_SHARED_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;-z noexecstack;-z relro;-z now;-z nodlopen"
+        "PROJ_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;SHELL: -z noexecstack;SHELL: -z relro;SHELL: -z now;SHELL: -z nodlopen",
+        "PROJ_SHARED_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;SHELL: -z noexecstack;SHELL: -z relro;SHELL: -z now;SHELL: -z nodlopen"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,8 +11,8 @@
       "hidden": true,
       "cacheVariables": {
         "PROJ_CXX_FLAGS": "-O3;-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=3;-D_GLIBCXX_ASSERTIONS=1;-fstack-protector-strong;-fcf-protection=full;-fstack-clash-protection;-Wall;-Wextra;-Wpedantic;-Wconversion;-Wsign-conversion;-Wcast-qual;-Wformat=2;-Wundef;-Werror=float-equal;-Wshadow;-Wcast-align;-Wunused;-Wnull-dereference;-Wdouble-promotion;-Wimplicit-fallthrough;-Wextra-semi;-Woverloaded-virtual;-Wnon-virtual-dtor;-Wold-style-cast",
-        "PROJ_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;-z,noexecstack;-z,relro;-z,now;-z,nodlopen",
-        "PROJ_SHARED_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;-z,noexecstack;-z,relro;-z,now;-z,nodlopen"
+        "PROJ_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;-znoexecstack;-zrelro;-znow;-znodlopen",
+        "PROJ_SHARED_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;-znoexecstack;-zrelro;-znow;-znodlopen"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,8 +11,8 @@
       "hidden": true,
       "cacheVariables": {
         "PROJ_CXX_FLAGS": "-O3;-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=3;-D_GLIBCXX_ASSERTIONS=1;-fstack-protector-strong;-fcf-protection=full;-fstack-clash-protection;-Wall;-Wextra;-Wpedantic;-Wconversion;-Wsign-conversion;-Wcast-qual;-Wformat=2;-Wundef;-Werror=float-equal;-Wshadow;-Wcast-align;-Wunused;-Wnull-dereference;-Wdouble-promotion;-Wimplicit-fallthrough;-Wextra-semi;-Woverloaded-virtual;-Wnon-virtual-dtor;-Wold-style-cast",
-        "PROJ_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;-znoexecstack;-zrelro;-znow;-znodlopen",
-        "PROJ_SHARED_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;-znoexecstack;-zrelro;-znow;-znodlopen"
+        "PROJ_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;-z noexecstack;-z relro;-z now;-z nodlopen",
+        "PROJ_SHARED_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed;-z noexecstack;-z relro;-z now;-z nodlopen"
       }
     },
     {

--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -52,9 +52,6 @@ if(BUILD_GLFW)
   set(GLFW_INSTALL
       OFF
       CACHE BOOL "Do not install the GLFW" FORCE)
-  set(BUILD_SHARED_LIBS
-      OFF
-      CACHE BOOL "Do not install the GLFW" FORCE)
 
   FetchContent_Declare(
     glfw
@@ -93,11 +90,6 @@ message(CHECK_PASS "fetched")
 if(BUILD_GLM)
   message(CHECK_START "Fetching GLM")
   list(APPEND CMAKE_MESSAGE_INDENT "  ")
-
-  set(BUILD_SHARED_LIBS
-      OFF
-      CACHE BOOL "Do not build glm as a shared
-library" FORCE)
 
   FetchContent_Declare(
     glm

--- a/libresin/CMakeLists.txt
+++ b/libresin/CMakeLists.txt
@@ -16,13 +16,9 @@ target_link_libraries(${PROJECT_NAME} PUBLIC glm::glm)
 
 # Set compile options and properties of the target
 target_compile_options(${PROJECT_NAME} PRIVATE ${PROJ_CXX_FLAGS})
-set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS
-                                                 "${PROJ_SHARED_LINKER_FLAGS}")
 
-if(DEFINED CLANG_TIDY_COMMAND AND NOT CLANG_TIDY_COMMAND STREQUAL "")
-  set_target_properties(libresin PROPERTIES CXX_CLANG_TIDY
-                                            "${CLANG_TIDY_COMMAND}")
-endif()
+# This is required when libresin is built as a shared library and is linked with shared libraries
+target_link_options(${PROJECT_NAME} PRIVATE ${PROJ_SHARED_LINKER_FLAGS})
 
 if(BUILD_TESTING)
   enable_testing()

--- a/resin/CMakeLists.txt
+++ b/resin/CMakeLists.txt
@@ -18,8 +18,9 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC GLFW_INCLUDE_NONE)
 
 # Set compile options and properties of the target
 target_compile_options(${PROJECT_NAME} PRIVATE ${PROJ_CXX_FLAGS})
-set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS
-                                                 "${PROJ_EXE_LINKER_FLAGS}")
+
+# This is required when resin is linked with shared libraries
+target_link_options(${PROJECT_NAME} PRIVATE ${PROJ_EXE_LINKER_FLAGS})
 
 if(BUILD_TESTING)
   enable_testing()


### PR DESCRIPTION
Quick overview:
1. Added `;` in the `PROJ_(CXX|EXE_LINKER|SHARED_LINKER)_FLAGS`.
2. Added `-O3` as it's required for `_FORTIFY_SOURCE` flag.