### PR TITLE
[SDF-69] Fix CMake repo version not found issue

### DIFF
--- a/.github/workflows/pull-request-tagger.yml
+++ b/.github/workflows/pull-request-tagger.yml
@@ -63,17 +63,38 @@ jobs:
         with:
           github-token: ${{ secrets.TAG_PAT }}
           script: |
-            github.rest.git.createRef({
+            const tagName = '${{ steps.determine-tag.outputs.tag }}';
+            const tagMessage = 'Annotated tag for release ' + tagName;
+            const tagSha = context.sha;
+
+            github.rest.git.createTag({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/${{ steps.determine-tag.outputs.tag }}',
-              sha: context.sha
-            }).catch(err => {
-              if (err.status !== 422) throw err;
-              github.rest.git.updateRef({
+              tag: tagName,
+              message: tagMessage,
+              object: tagSha,
+              type: 'commit',
+              tagger: {
+                name: 'GitHub Actions',
+                email: 'actions@github.com',
+                date: new Date().toISOString()
+              }
+            }).then(tagResponse => {
+              const annotatedTagSha = tagResponse.data.sha;
+
+              return github.rest.git.createRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                ref: 'tags/${{ steps.determine-tag.outputs.tag }}',
-                sha: context.sha
+                ref: `refs/tags/${tagName}`,
+                sha: annotatedTagSha
               });
-            })
+            }).catch(err => {
+              if (err.status !== 422) throw err;
+              return github.rest.git.updateRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `refs/tags/${tagName}`,
+                sha: tagSha
+              });
+            });
+            

--- a/cmake/find_repo_version.cmake
+++ b/cmake/find_repo_version.cmake
@@ -3,6 +3,8 @@
 # the following pattern: `v?[0-9]+.[0-9]+(.[0-9]+)?`. If the branch is ahead of
 # the latest tag, the version is marked as unstable.
 #
+# Note: Lightweight tags are ignored.
+#
 # WARNING: `find_package(Git)` call might be necessary before calling this
 # function.
 function(find_repo_version VERSION IS_STABLE)


### PR DESCRIPTION
The CMake script extracts versions basing on the annotated tags, for that reason the PR tagger should create annotated tags for releases.

Basing on [this](https://docs.github.com/en/rest/git/tags?apiVersion=2022-11-28), I've (hopefully) managed to fix this issue.