### PR TITLE
Fix dirty primitives

### DIFF
--- a/libresin/libresin/core/sdf_tree/group_node.cpp
+++ b/libresin/libresin/core/sdf_tree/group_node.cpp
@@ -327,7 +327,7 @@ void GroupNode::insert_after_child(std::optional<IdView<SDFTreeNodeId>> after_ch
 
 void GroupNode::push_dirty_primitives() {
   for (auto prim : leaves_) {
-    tree_registry_.dirty_primitives.push_back(std::move(prim));
+    tree_registry_.dirty_primitives.emplace(std::move(prim));
   }
 }
 

--- a/libresin/libresin/core/sdf_tree/primitive_base_node.hpp
+++ b/libresin/libresin/core/sdf_tree/primitive_base_node.hpp
@@ -85,7 +85,7 @@ class BasePrimitiveNode : public SDFTreeNode {
     leaves.erase(leaves.find(node_id()));
   }
 
-  inline void push_dirty_primitives() final { tree_registry_.dirty_primitives.emplace_back(node_id()); }
+  inline void push_dirty_primitives() final { tree_registry_.dirty_primitives.emplace(node_id()); }
   inline void set_ancestor_mat_id(IdView<MaterialId> mat_id) final { ancestor_mat_id_ = mat_id; }
   inline void remove_ancestor_mat_id() final { ancestor_mat_id_ = std::nullopt; }
   inline void delete_material_from_subtree(IdView<MaterialId> mat_id) final {

--- a/libresin/libresin/core/sdf_tree/sdf_tree.hpp
+++ b/libresin/libresin/core/sdf_tree/sdf_tree.hpp
@@ -27,7 +27,7 @@ class SDFTree {
   void visit_all_primitives(ISDFTreeNodeVisitor& visitor);
   void visit_node(IdView<SDFTreeNodeId> node_id, ISDFTreeNodeVisitor& visitor);
 
-  inline std::vector<IdView<SDFTreeNodeId>> dirty_primitives() const { return sdf_tree_registry_.dirty_primitives; }
+  inline const SDFTreeRegistry::PrimitivesSet& dirty_primitives() const { return sdf_tree_registry_.dirty_primitives; }
 
   // Cost O(1)
   SDFTreeNode& node(IdView<SDFTreeNodeId> node_id);
@@ -69,7 +69,7 @@ class SDFTree {
   // Note: Throws if the `mat_id` is the default material id.
   void delete_material(IdView<MaterialId> mat_id);
 
-  inline void mark_material_dirty(IdView<MaterialId> mat_id) { sdf_tree_registry_.dirty_materials.push_back(mat_id); }
+  inline void mark_material_dirty(IdView<MaterialId> mat_id) { sdf_tree_registry_.dirty_materials.insert(mat_id); }
 
   // Note: The vector does not contain the default material.
   inline const std::vector<IdView<MaterialId>>& materials() const { return material_active_ids_; }

--- a/libresin/libresin/core/sdf_tree/sdf_tree_node.cpp
+++ b/libresin/libresin/core/sdf_tree/sdf_tree_node.cpp
@@ -17,12 +17,6 @@ SDFTreeNode::~SDFTreeNode() {
   Logger::debug("Destructed node with id={}.", node_id_.raw());
 }
 
-void SDFTreeNode::mark_dirty() {
-  if (tree_registry_.nodes_registry.get_max_objs() < tree_registry_.dirty_primitives.size()) {
-    log_throw(SDFTreeReachedDirtyPrimitivesLimit());
-  }
-
-  push_dirty_primitives();
-}
+void SDFTreeNode::mark_dirty() { push_dirty_primitives(); }
 
 }  // namespace resin

--- a/libresin/libresin/core/sdf_tree/sdf_tree_registry.hpp
+++ b/libresin/libresin/core/sdf_tree/sdf_tree_registry.hpp
@@ -13,6 +13,9 @@ template <sdf_shader_consts::SDFShaderPrim PrimType>
 class PrimitiveNode;
 
 struct SDFTreeRegistry {
+  using PrimitivesSet = std::unordered_set<IdView<SDFTreeNodeId>, IdViewHash<SDFTreeNodeId>, std::equal_to<>>;
+  using MaterialsSet  = std::unordered_set<IdView<MaterialId>, IdViewHash<MaterialId>, std::equal_to<>>;
+
   // TODO(SDF-98): allow specifying the sizes
   SDFTreeRegistry()
       : sphere_components_registry(IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Sphere>>(100)),
@@ -24,7 +27,6 @@ struct SDFTreeRegistry {
         default_material(*this) {
     all_nodes.resize(nodes_registry.get_max_objs());
     all_group_nodes.resize(nodes_registry.get_max_objs());
-    dirty_primitives.reserve(nodes_registry.get_max_objs());
   }
 
   IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Sphere>> sphere_components_registry;
@@ -49,10 +51,10 @@ struct SDFTreeRegistry {
   std::vector<std::optional<std::reference_wrapper<SDFTreeNode>>> all_nodes;
   std::vector<std::optional<std::reference_wrapper<GroupNode>>> all_group_nodes;
 
-  std::vector<IdView<SDFTreeNodeId>> dirty_primitives;
+  PrimitivesSet dirty_primitives;
 
   IdRegistry<Material> materials_registry;
-  std::vector<IdView<MaterialId>> dirty_materials;
+  MaterialsSet dirty_materials;
 
   // Required for shader generation
   MaterialSDFTreeComponent default_material;


### PR DESCRIPTION
Replaced `std::vector` with `std::unordered_set` for dirty primitives stored in the tree and removed `SDFTreeReachedDirtyPrimitivesLimit` throw. The vector was too optimistic approach, when `resin.cpp` complexity increases it gets difficult to manage.