### PR TITLE
[SDF-111] Add translation/rotation/scale gizmo

### DIFF
--- a/THIRD_PARTY_LICENSES/imguizmo_LICENSE
+++ b/THIRD_PARTY_LICENSES/imguizmo_LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Cedric Guillemet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -85,6 +85,24 @@ list(POP_BACK CMAKE_MESSAGE_INDENT)
 message(CHECK_PASS "fetched")
 
 # ##############################################################################
+# ImGuizmo (depends on ImGui)
+# ##############################################################################
+message(CHECK_START "Fetching ImGuizmo")
+list(APPEND CMAKE_MESSAGE_INDENT "  ")
+
+FetchContent_Declare(
+  imguizmo 
+  GIT_REPOSITORY "https://github.com/CedricGuillemet/ImGuizmo.git"
+  GIT_TAG "1.83"
+  PATCH_COMMAND git apply --ignore-whitespace
+                "${CMAKE_CURRENT_LIST_DIR}/../../patches/imguizmo.patch"
+  UPDATE_DISCONNECTED 1)
+FetchContent_MakeAvailable(imguizmo)
+
+list(POP_BACK CMAKE_MESSAGE_INDENT)
+message(CHECK_PASS "fetched")
+
+# ##############################################################################
 # GLM
 # ##############################################################################
 if(BUILD_GLM)

--- a/libresin/libresin/core/camera.cpp
+++ b/libresin/libresin/core/camera.cpp
@@ -1,3 +1,5 @@
+#include <glm/ext/matrix_clip_space.hpp>
+#include <glm/gtc/type_ptr.hpp>
 #include <libresin/core/camera.hpp>
 
 namespace resin {
@@ -38,5 +40,13 @@ void Camera::update_dimensions() {
 
 glm::mat4 Camera::view_matrix() const { return transform.world_to_local_matrix(); }
 glm::mat4 Camera::inverse_view_matrix() const { return transform.local_to_world_matrix(); }
+
+glm::mat4 Camera::proj_matrix() const {
+  if (is_orthographic) {
+    return glm::ortho(-width_ / 2.0F, width_ / 2.0F, -height_ / 2.0F, height_ / 2.0F, near_plane_, far_plane_);
+  }
+
+  return glm::perspective(glm::radians(fov_), aspect_ratio_, near_plane_, far_plane_);
+}
 
 }  // namespace resin

--- a/libresin/libresin/core/camera.hpp
+++ b/libresin/libresin/core/camera.hpp
@@ -25,6 +25,7 @@ class Camera {
 
   glm::mat4 view_matrix() const;
   glm::mat4 inverse_view_matrix() const;
+  glm::mat4 proj_matrix() const;
 
  private:
   float fov_;  // only apparent if orthographic

--- a/libresin/libresin/core/sdf_tree/sdf_tree.cpp
+++ b/libresin/libresin/core/sdf_tree/sdf_tree.cpp
@@ -56,7 +56,9 @@ GroupNode& SDFTree::group(IdView<SDFTreeNodeId> node_id) {
 
 void SDFTree::visit_dirty_primitives(ISDFTreeNodeVisitor& visitor) {
   for (auto prim : sdf_tree_registry_.dirty_primitives) {
-    sdf_tree_registry_.all_nodes[prim.raw()]->get().accept_visitor(visitor);
+    if (sdf_tree_registry_.all_nodes[prim.raw()].has_value()) {
+      sdf_tree_registry_.all_nodes[prim.raw()]->get().accept_visitor(visitor);
+    }
   }
   mark_primitives_clean();
 }

--- a/libresin/libresin/core/transform.cpp
+++ b/libresin/libresin/core/transform.cpp
@@ -30,6 +30,11 @@ void Transform::set_parent(const std::optional<std::reference_wrapper<Transform>
   parent_->get().children_.emplace_back(*this);
 }
 
+void Transform::move_local(const glm::vec3& delta) {
+  pos_ += delta;
+  mark_dirty();
+}
+
 void Transform::rotate(const glm::vec3& axis, const float angle) {
   rot_ = glm::rotate(rot_, angle, axis);
   mark_dirty();

--- a/libresin/libresin/core/transform.hpp
+++ b/libresin/libresin/core/transform.hpp
@@ -21,6 +21,8 @@ struct Transform final {
   const Transform& parent() const { return *parent_; }
   void set_parent(std::optional<std::reference_wrapper<Transform>> parent);
 
+  void move_local(const glm::vec3& delta);
+
   void rotate(const glm::vec3& axis, float angle);
   void rotate(const glm::quat& rotation);
   void rotate_local(const glm::quat& rotation);

--- a/patches/imguizmo.patch
+++ b/patches/imguizmo.patch
@@ -1,0 +1,112 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..73513a9
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,14 @@
++cmake_minimum_required(VERSION 3.20)
++
++project(imguizmo)
++message(STATUS "Configuring " ${PROJECT_NAME})
++
++set(CMAKE_CXX_STANDARD 11)
++set(CMAKE_DISABLE_IN_SOURCE_BUILD TRUE)
++
++file(GLOB IMGUI_SOURCE_FILES
++  "src/imguizmo/*.cpp")
++
++add_library(${PROJECT_NAME} STATIC ${IMGUI_SOURCE_FILES})
++target_link_libraries(${PROJECT_NAME} PUBLIC imgui)
++target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC src)
+diff --git a/ImGuizmo.cpp b/src/imguizmo/ImGuizmo.cpp
+similarity index 99%
+rename from ImGuizmo.cpp
+rename to src/imguizmo/ImGuizmo.cpp
+index ed05fd8..82e503f 100644
+--- a/ImGuizmo.cpp
++++ b/src/imguizmo/ImGuizmo.cpp
+@@ -23,12 +23,9 @@
+ // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ // SOFTWARE.
+ //
+-
+-#include "imgui.h"
+-#ifndef IMGUI_DEFINE_MATH_OPERATORS
+ #define IMGUI_DEFINE_MATH_OPERATORS
+-#endif
+-#include "imgui_internal.h"
++#include <imgui/imgui.h>
++#include <imgui/imgui_internal.h>
+ #include "ImGuizmo.h"
+ 
+ #if defined(_MSC_VER) || defined(__MINGW32__)
+@@ -1878,7 +1875,7 @@ namespace ImGuizmo
+       // move
+       if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsTranslateType(gContext.mCurrentOperation))
+       {
+-         ImGui::CaptureMouseFromApp();
++         
+          const float len = fabsf(IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan)); // near plan
+          vec_t newPos = gContext.mRayOrigin + gContext.mRayVector * len;
+ 
+@@ -1948,7 +1945,7 @@ namespace ImGuizmo
+          type = GetMoveType(op, &gizmoHitProportion);
+          if (type != MT_NONE)
+          {
+-            ImGui::CaptureMouseFromApp();
++            
+          }
+          if (CanActivate() && type != MT_NONE)
+          {
+@@ -1993,7 +1990,7 @@ namespace ImGuizmo
+          type = GetScaleType(op);
+          if (type != MT_NONE)
+          {
+-            ImGui::CaptureMouseFromApp();
++            
+          }
+          if (CanActivate() && type != MT_NONE)
+          {
+@@ -2016,7 +2013,7 @@ namespace ImGuizmo
+       // scale
+       if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsScaleType(gContext.mCurrentOperation))
+       {
+-         ImGui::CaptureMouseFromApp();
++         
+          const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan);
+          vec_t newPos = gContext.mRayOrigin + gContext.mRayVector * len;
+          vec_t newOrigin = newPos - gContext.mRelativeOrigin * gContext.mScreenFactor;
+@@ -2107,7 +2104,7 @@ namespace ImGuizmo
+ 
+          if (type != MT_NONE)
+          {
+-            ImGui::CaptureMouseFromApp();
++            
+          }
+ 
+          if (type == MT_ROTATE_SCREEN)
+@@ -2141,7 +2138,7 @@ namespace ImGuizmo
+       // rotation
+       if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsRotateType(gContext.mCurrentOperation))
+       {
+-         ImGui::CaptureMouseFromApp();
++         
+          gContext.mRotationAngle = ComputeAngleOnPlan();
+          if (snap)
+          {
+diff --git a/ImGuizmo.h b/src/imguizmo/ImGuizmo.h
+similarity index 97%
+rename from ImGuizmo.h
+rename to src/imguizmo/ImGuizmo.h
+index 155202d..d494ec1 100644
+--- a/ImGuizmo.h
++++ b/src/imguizmo/ImGuizmo.h
+@@ -105,7 +105,7 @@ void EditTransform(const Camera& camera, matrix_t& matrix)
+ #pragma once
+ 
+ #ifdef USE_IMGUI_API
+-#include "imconfig.h"
++#include <imgui/imconfig.h>
+ #endif
+ #ifndef IMGUI_API
+ #define IMGUI_API

--- a/resin/CMakeLists.txt
+++ b/resin/CMakeLists.txt
@@ -11,7 +11,7 @@ file(GLOB_RECURSE SOURCES
 
 add_executable(${PROJECT_NAME} ${SOURCES})
 
-target_link_libraries(${PROJECT_NAME} PUBLIC glfw libresin glm::glm imgui glad nfd)
+target_link_libraries(${PROJECT_NAME} PUBLIC glfw libresin glm::glm imgui glad nfd imguizmo)
 target_include_directories(${PROJECT_NAME}
                            PUBLIC . "${CMAKE_BINARY_DIR}/generated")
 

--- a/resin/assets/test.frag
+++ b/resin/assets/test.frag
@@ -3,15 +3,13 @@
 layout(location = 0) out vec4 fragColor;
 
 // fragment
-in vec3 v_Pos;
+in vec2 v_Pos;
 
 // camera
 uniform mat4 u_iV;
 uniform bool u_ortho;
-uniform vec2 u_resolution;
 uniform float u_nearPlane;
 uniform float u_farPlane;
-uniform float u_camSize;
 
 #include "blinn_phong.glsl"
 #include "sdf.glsl"
@@ -101,12 +99,12 @@ vec3 render( vec3 ray_origin, vec3 ray_direction )
 }
 
 void main() {
-    vec2 pos = (2.0*gl_FragCoord.xy-u_resolution)/u_resolution.y;
+    vec2 pos = v_Pos;
 
     vec4 ray_origin;    // vec4(ro, 1) as it needs to be translated
     vec4 ray_direction; // vec4(rd, 0) as it cannot be translated
     if (u_ortho) {
-        ray_origin = vec4(vec3(u_camSize * pos, 0), 1); // apply desired scaling from fov
+        ray_origin = vec4(vec3(pos, 0), 1);
         ray_direction = vec4(0, 0, -1, 0);
     } else {
         ray_origin = vec4(0, 0, 0, 1); 

--- a/resin/assets/test.frag
+++ b/resin/assets/test.frag
@@ -4,12 +4,14 @@ layout(location = 0) out vec4 fragColor;
 
 // fragment
 in vec2 v_Pos;
+in vec2 v_ndcPos;
 
 // camera
 uniform mat4 u_iV;
 uniform bool u_ortho;
 uniform float u_nearPlane;
 uniform float u_farPlane;
+uniform mat4 u_iP; //temp
 
 #include "blinn_phong.glsl"
 #include "sdf.glsl"
@@ -99,16 +101,25 @@ vec3 render( vec3 ray_origin, vec3 ray_direction )
 }
 
 void main() {
-    vec2 pos = v_Pos;
 
     vec4 ray_origin;    // vec4(ro, 1) as it needs to be translated
     vec4 ray_direction; // vec4(rd, 0) as it cannot be translated
     if (u_ortho) {
+
+        vec2 pos = v_Pos;
         ray_origin = vec4(vec3(pos, 0), 1);
         ray_direction = vec4(0, 0, -1, 0);
     } else {
+        
+        vec2 pos = v_ndcPos;
         ray_origin = vec4(0, 0, 0, 1); 
         ray_direction = vec4(normalize(vec3(pos, -u_nearPlane)), 0);
+
+        // begin: temp
+        vec4 temp = u_iP * vec4(pos, 1.0, 1.0); 
+        temp /= temp.w;
+        ray_direction = vec4(normalize(temp.xyz), 0);
+        // end: temp
     }
     
     vec3 color = render((u_iV * ray_origin).xyz, ((u_iV * ray_direction).xyz));

--- a/resin/assets/test.frag
+++ b/resin/assets/test.frag
@@ -4,14 +4,12 @@ layout(location = 0) out vec4 fragColor;
 
 // fragment
 in vec2 v_Pos;
-in vec2 v_ndcPos;
 
 // camera
 uniform mat4 u_iV;
 uniform bool u_ortho;
 uniform float u_nearPlane;
 uniform float u_farPlane;
-uniform mat4 u_iP; //temp
 
 #include "blinn_phong.glsl"
 #include "sdf.glsl"
@@ -110,16 +108,9 @@ void main() {
         ray_origin = vec4(vec3(pos, 0), 1);
         ray_direction = vec4(0, 0, -1, 0);
     } else {
-        
-        vec2 pos = v_ndcPos;
+        vec2 pos = v_Pos;
         ray_origin = vec4(0, 0, 0, 1); 
         ray_direction = vec4(normalize(vec3(pos, -u_nearPlane)), 0);
-
-        // begin: temp
-        vec4 temp = u_iP * vec4(pos, 1.0, 1.0); 
-        temp /= temp.w;
-        ray_direction = vec4(normalize(temp.xyz), 0);
-        // end: temp
     }
     
     vec3 color = render((u_iV * ray_origin).xyz, ((u_iV * ray_direction).xyz));

--- a/resin/assets/test.vert
+++ b/resin/assets/test.vert
@@ -8,7 +8,7 @@ uniform float u_camSize;
 out vec2 v_Pos;
 
 void main() {
-    v_Pos = a_Position.xy * u_camSize / 2.0;
+    v_Pos = a_Position.xy * u_camSize / 2.0; // the division by 2 is required to match the glm::perspective
     v_Pos.x *= u_resolution.x / u_resolution.y;
 
     gl_Position = vec4(a_Position, 1.0);

--- a/resin/assets/test.vert
+++ b/resin/assets/test.vert
@@ -6,13 +6,10 @@ uniform vec2 u_resolution;
 uniform float u_camSize;
 
 out vec2 v_Pos;
-out vec2 v_ndcPos;
 
 void main() {
-    v_Pos = a_Position.xy * u_camSize;
+    v_Pos = a_Position.xy * u_camSize / 2.0;
     v_Pos.x *= u_resolution.x / u_resolution.y;
-
-    v_ndcPos = a_Position.xy;
 
     gl_Position = vec4(a_Position, 1.0);
 }

--- a/resin/assets/test.vert
+++ b/resin/assets/test.vert
@@ -4,10 +4,15 @@ layout(location = 0) in vec3 a_Position;
 
 uniform vec2 u_resolution;
 uniform float u_camSize;
+
 out vec2 v_Pos;
+out vec2 v_ndcPos;
 
 void main() {
     v_Pos = a_Position.xy * u_camSize;
     v_Pos.x *= u_resolution.x / u_resolution.y;
+
+    v_ndcPos = a_Position.xy;
+
     gl_Position = vec4(a_Position, 1.0);
 }

--- a/resin/assets/test.vert
+++ b/resin/assets/test.vert
@@ -2,9 +2,12 @@
 				
 layout(location = 0) in vec3 a_Position;
 
-out vec3 v_Pos;
+uniform vec2 u_resolution;
+uniform float u_camSize;
+out vec2 v_Pos;
 
 void main() {
-    v_Pos = a_Position;
+    v_Pos = a_Position.xy * u_camSize;
+    v_Pos.x *= u_resolution.x / u_resolution.y;
     gl_Position = vec4(a_Position, 1.0);
 }

--- a/resin/resin/core/window.cpp
+++ b/resin/resin/core/window.cpp
@@ -3,6 +3,7 @@
 #include <imgui/imgui_impl_glfw.h>
 #include <imgui/imgui_impl_opengl3.h>
 #include <imgui/imgui_impl_opengl3_loader.h>
+#include <imguizmo/ImGuizmo.h>
 
 #include <cstdlib>
 #include <libresin/utils/logger.hpp>
@@ -36,6 +37,7 @@ void Window::api_init() {
   io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 
   imgui_set_style();
+  ImGuizmo::SetImGuiContext(ImGui::GetCurrentContext());
 
   Logger::debug("Api init");
 }

--- a/resin/resin/imgui/sdf_tree.cpp
+++ b/resin/resin/imgui/sdf_tree.cpp
@@ -266,6 +266,11 @@ void SDFTreeComponentVisitor::render_tree() {
 
 std::unique_ptr<::resin::SDFTreeNode> SDFTreeComponentVisitor::fix_transform_and_detach(
     ::resin::IdView<::resin::SDFTreeNodeId> source, ::resin::IdView<::resin::SDFTreeNodeId> new_parent) {
+  if (sdf_tree_.node(source).parent().node_id() == new_parent) {
+    auto node_ptr = sdf_tree_.node(source).parent().detach_child(source);
+    return node_ptr;
+  }
+
   // this way from the user point of view transform of the node will not change
   const auto& old_world_mat            = sdf_tree_.node(source).transform().local_to_world_matrix();
   const auto& new_parent_world_inv_mat = sdf_tree_.node(new_parent).transform().world_to_local_matrix();
@@ -301,26 +306,16 @@ void SDFTreeComponentVisitor::apply_move_operation() {
   }
 
   if (move_before_target_.has_value() && !move_before_target_->expired()) {
-    if (sdf_tree_.node(*move_source_target_).parent() != sdf_tree_.node(*move_before_target_).parent()) {
-      auto node_ptr =
-          fix_transform_and_detach(*move_source_target_, sdf_tree_.node(*move_before_target_).parent().node_id());
-      sdf_tree_.node(*move_before_target_).parent().insert_before_child(*move_before_target_, std::move(node_ptr));
-    } else {
-      auto node_ptr = sdf_tree_.node(*move_source_target_).parent().detach_child(*move_source_target_);
-      sdf_tree_.node(*move_before_target_).parent().insert_before_child(*move_before_target_, std::move(node_ptr));
-    }
+    auto node_ptr =
+        fix_transform_and_detach(*move_source_target_, sdf_tree_.node(*move_before_target_).parent().node_id());
+    sdf_tree_.node(*move_before_target_).parent().insert_before_child(*move_before_target_, std::move(node_ptr));
     return;
   }
 
   if (move_after_target_.has_value() && !move_after_target_->expired()) {
-    if (sdf_tree_.node(*move_source_target_).parent() != sdf_tree_.node(*move_after_target_).parent()) {
-      auto node_ptr =
-          fix_transform_and_detach(*move_source_target_, sdf_tree_.node(*move_after_target_).parent().node_id());
-      sdf_tree_.node(*move_after_target_).parent().insert_after_child(*move_after_target_, std::move(node_ptr));
-    } else {
-      auto node_ptr = sdf_tree_.node(*move_source_target_).parent().detach_child(*move_source_target_);
-      sdf_tree_.node(*move_after_target_).parent().insert_after_child(*move_after_target_, std::move(node_ptr));
-    }
+    auto node_ptr =
+        fix_transform_and_detach(*move_source_target_, sdf_tree_.node(*move_after_target_).parent().node_id());
+    sdf_tree_.node(*move_after_target_).parent().insert_after_child(*move_after_target_, std::move(node_ptr));
     return;
   }
 }

--- a/resin/resin/imgui/sdf_tree.hpp
+++ b/resin/resin/imgui/sdf_tree.hpp
@@ -9,6 +9,7 @@
 #include <libresin/core/sdf_tree/sdf_tree.hpp>
 #include <libresin/core/sdf_tree/sdf_tree_node.hpp>
 #include <libresin/core/sdf_tree/sdf_tree_node_visitor.hpp>
+#include <memory>
 #include <optional>
 
 namespace ImGui {  // NOLINT
@@ -32,6 +33,8 @@ class SDFTreeComponentVisitor : public ::resin::ISDFTreeNodeVisitor {
   void render_op(::resin::SDFTreeNode& node) const;
   void drag_and_drop(::resin::SDFTreeNode& node, bool ignore_middle);
   std::optional<::resin::IdView<::resin::SDFTreeNodeId>> get_curr_payload();
+  std::unique_ptr<::resin::SDFTreeNode> fix_transform_and_detach(::resin::IdView<::resin::SDFTreeNodeId> source,
+                                                                 ::resin::IdView<::resin::SDFTreeNodeId> new_parent);
 
  private:
   std::optional<::resin::IdView<::resin::SDFTreeNodeId>> selected_ = std::nullopt;

--- a/resin/resin/imgui/transform_gizmo.cpp
+++ b/resin/resin/imgui/transform_gizmo.cpp
@@ -2,15 +2,20 @@
 #include <imguizmo/ImGuizmo.h>
 
 #include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
 #include <glm/gtc/type_ptr.hpp>
+#include <glm/matrix.hpp>
+#include <libresin/core/transform.hpp>
 #include <resin/imgui/transform_gizmo.hpp>
 
 namespace ImGui {  // NOLINT
 
 namespace resin {
 
-bool TranslationGizmo(::resin::Transform& trans, const ::resin::Camera& camera, GizmoMode mode, float width,
-                      float height) {
+bool TransformGizmo(::resin::Transform& trans, const ::resin::Camera& camera, GizmoMode mode, GizmoOperation operation,
+                    float width, float height)
+
+{
   auto view      = camera.view_matrix();
   auto proj      = camera.proj_matrix();
   auto delta_mat = glm::mat4(1.0F);
@@ -22,58 +27,72 @@ bool TranslationGizmo(::resin::Transform& trans, const ::resin::Camera& camera, 
   ImGuizmo::SetRect(ImGui::GetWindowPos().x + ImGui::GetCursorStartPos().x,
                     ImGui::GetWindowPos().y + ImGui::GetCursorStartPos().y, width, height);
 
-  if (ImGuizmo::Manipulate(glm::value_ptr(view), glm::value_ptr(proj), ImGuizmo::OPERATION::TRANSLATE,
-                           mode == GizmoMode::Local ? ImGuizmo::MODE::LOCAL : ImGuizmo::MODE::WORLD,
-                           glm::value_ptr(mat), glm::value_ptr(delta_mat))) {
-    auto dp = glm::vec3(delta_mat[3][0], delta_mat[3][1], delta_mat[3][2]);
-    trans.move_local(dp);
+  if (operation == GizmoOperation::Translation) {
+    if (ImGuizmo::Manipulate(glm::value_ptr(view), glm::value_ptr(proj), ImGuizmo::OPERATION::TRANSLATE,
+                             mode == GizmoMode::Local ? ImGuizmo::MODE::LOCAL : ImGuizmo::MODE::WORLD,
+                             glm::value_ptr(mat), glm::value_ptr(delta_mat))) {
+      auto dp = glm::vec3(delta_mat[3]);
+      if (trans.has_parent()) {
+        auto parent_rot_mat = glm::mat4_cast(trans.parent().rot());
+        dp                  = glm::vec3(glm::transpose(parent_rot_mat) * glm::vec4(dp, 1.0F));
+      }
+      trans.move_local(dp);
 
-    return true;
-  }
-  return false;
-}
-
-bool RotationGizmo(::resin::Transform& trans, const ::resin::Camera& camera, GizmoMode mode, float width,
-                   float height) {
-  auto view      = camera.view_matrix();
-  auto proj      = camera.proj_matrix();
-  auto delta_mat = glm::mat4(1.0F);
-  auto mat       = trans.local_to_world_matrix();
-
-  ImGuizmo::BeginFrame();
-  ImGuizmo::SetDrawlist();
-  ImGuizmo::SetOrthographic(camera.is_orthographic);
-  ImGuizmo::SetRect(ImGui::GetWindowPos().x + ImGui::GetCursorStartPos().x,
-                    ImGui::GetWindowPos().y + ImGui::GetCursorStartPos().y, width, height);
-
-  if (ImGuizmo::Manipulate(glm::value_ptr(view), glm::value_ptr(proj), ImGuizmo::OPERATION::ROTATE,
-                           mode == GizmoMode::Local ? ImGuizmo::MODE::LOCAL : ImGuizmo::MODE::WORLD,
-                           glm::value_ptr(mat), glm::value_ptr(delta_mat))) {
-    auto dq = glm::quat_cast(delta_mat);
-    if (trans.has_parent()) {
-      auto pq = trans.parent().rot();
-
-      // new world rotation:
-      //
-      //      q_new = dq * pq * q,
-      //
-      // where q is the current local rotation of the object, pq is the parent
-      // world rotation and dq is delta obtained from the ImGuizmo
-      //
-      // however we can only influence the q, so we need dq' that could be
-      // plugged in like this:
-      //
-      //      q_new = pq * dq' * q
-      //
-      // from dq * pq * q = pq * dq' * q, we get
-      //
-      //      dq' = pq^{-1} * dq * pq
-
-      dq = glm::normalize(glm::quat(pq.w, -pq.x, -pq.y, -pq.z) * dq * pq);
+      return true;
     }
-    trans.rotate(dq);
+    return false;
+  }
+
+  if (operation == GizmoOperation::Rotation) {
+    if (ImGuizmo::Manipulate(glm::value_ptr(view), glm::value_ptr(proj), ImGuizmo::OPERATION::ROTATE,
+                             mode == GizmoMode::Local ? ImGuizmo::MODE::LOCAL : ImGuizmo::MODE::WORLD,
+                             glm::value_ptr(mat), glm::value_ptr(delta_mat))) {
+      auto dq = glm::quat_cast(delta_mat);
+      if (trans.has_parent()) {
+        auto pq = trans.parent().rot();
+
+        // new world rotation:
+        //
+        //      q_new = dq * pq * q,
+        //
+        // where q is the current local rotation of the object, pq is the parent
+        // world rotation and dq is delta obtained from the ImGuizmo
+        //
+        // however we can only influence the q, so we need dq' that could be
+        // plugged in like this:
+        //
+        //      q_new = pq * dq' * q
+        //
+        // from dq * pq * q = pq * dq' * q, we get
+        //
+        //      dq' = pq^{-1} * dq * pq
+
+        dq = glm::normalize(glm::inverse(pq) * dq * pq);
+      }
+      trans.rotate(dq);
+      return true;
+    }
+    return false;
+  }
+
+  if (ImGuizmo::Manipulate(glm::value_ptr(view), glm::value_ptr(proj), ImGuizmo::OPERATION::SCALE,
+                           ImGuizmo::MODE::WORLD, glm::value_ptr(mat))) {
+    constexpr float kFloatEqTreshold = 1e-5F;
+
+    // Uniform scaling
+    if (std::abs(mat[1][1] - mat[0][0]) > kFloatEqTreshold) {
+      if (std::abs(mat[1][1] - mat[2][2]) > kFloatEqTreshold) {
+        trans.set_local_scale(mat[1][1]);
+      } else {
+        trans.set_local_scale(mat[0][0]);
+      }
+    } else if (std::abs(mat[2][2] - mat[0][0]) > kFloatEqTreshold) {
+      trans.set_local_scale(mat[2][2]);
+    }
+
     return true;
   }
+
   return false;
 }
 

--- a/resin/resin/imgui/transform_gizmo.cpp
+++ b/resin/resin/imgui/transform_gizmo.cpp
@@ -1,0 +1,82 @@
+#include <imgui/imgui.h>
+#include <imguizmo/ImGuizmo.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <resin/imgui/transform_gizmo.hpp>
+
+namespace ImGui {  // NOLINT
+
+namespace resin {
+
+bool TranslationGizmo(::resin::Transform& trans, const ::resin::Camera& camera, GizmoMode mode, float width,
+                      float height) {
+  auto view      = camera.view_matrix();
+  auto proj      = camera.proj_matrix();
+  auto delta_mat = glm::mat4(1.0F);
+  auto mat       = trans.local_to_world_matrix();
+
+  ImGuizmo::BeginFrame();
+  ImGuizmo::SetDrawlist();
+  ImGuizmo::SetOrthographic(camera.is_orthographic);
+  ImGuizmo::SetRect(ImGui::GetWindowPos().x + ImGui::GetCursorStartPos().x,
+                    ImGui::GetWindowPos().y + ImGui::GetCursorStartPos().y, width, height);
+
+  if (ImGuizmo::Manipulate(glm::value_ptr(view), glm::value_ptr(proj), ImGuizmo::OPERATION::TRANSLATE,
+                           mode == GizmoMode::Local ? ImGuizmo::MODE::LOCAL : ImGuizmo::MODE::WORLD,
+                           glm::value_ptr(mat), glm::value_ptr(delta_mat))) {
+    auto dp = glm::vec3(delta_mat[3][0], delta_mat[3][1], delta_mat[3][2]);
+    trans.move_local(dp);
+
+    return true;
+  }
+  return false;
+}
+
+bool RotationGizmo(::resin::Transform& trans, const ::resin::Camera& camera, GizmoMode mode, float width,
+                   float height) {
+  auto view      = camera.view_matrix();
+  auto proj      = camera.proj_matrix();
+  auto delta_mat = glm::mat4(1.0F);
+  auto mat       = trans.local_to_world_matrix();
+
+  ImGuizmo::BeginFrame();
+  ImGuizmo::SetDrawlist();
+  ImGuizmo::SetOrthographic(camera.is_orthographic);
+  ImGuizmo::SetRect(ImGui::GetWindowPos().x + ImGui::GetCursorStartPos().x,
+                    ImGui::GetWindowPos().y + ImGui::GetCursorStartPos().y, width, height);
+
+  if (ImGuizmo::Manipulate(glm::value_ptr(view), glm::value_ptr(proj), ImGuizmo::OPERATION::ROTATE,
+                           mode == GizmoMode::Local ? ImGuizmo::MODE::LOCAL : ImGuizmo::MODE::WORLD,
+                           glm::value_ptr(mat), glm::value_ptr(delta_mat))) {
+    auto dq = glm::quat_cast(delta_mat);
+    if (trans.has_parent()) {
+      auto pq = trans.parent().rot();
+
+      // new world rotation:
+      //
+      //      q_new = dq * pq * q,
+      //
+      // where q is the current local rotation of the object, pq is the parent
+      // world rotation and dq is delta obtained from the ImGuizmo
+      //
+      // however we can only influence the q, so we need dq' that could be
+      // plugged in like this:
+      //
+      //      q_new = pq * dq' * q
+      //
+      // from dq * pq * q = pq * dq' * q, we get
+      //
+      //      dq' = pq^{-1} * dq * pq
+
+      dq = glm::normalize(glm::quat(pq.w, -pq.x, -pq.y, -pq.z) * dq * pq);
+    }
+    trans.rotate(dq);
+    return true;
+  }
+  return false;
+}
+
+}  // namespace resin
+
+}  // namespace ImGui

--- a/resin/resin/imgui/transform_gizmo.cpp
+++ b/resin/resin/imgui/transform_gizmo.cpp
@@ -79,7 +79,7 @@ bool TransformGizmo(::resin::Transform& trans, const ::resin::Camera& camera, Gi
                            ImGuizmo::MODE::WORLD, glm::value_ptr(mat))) {
     constexpr float kFloatEqTreshold = 1e-5F;
 
-    // Uniform scaling
+    // Assuming uniform scaling
     if (std::abs(mat[1][1] - mat[0][0]) > kFloatEqTreshold) {
       if (std::abs(mat[1][1] - mat[2][2]) > kFloatEqTreshold) {
         trans.set_local_scale(mat[1][1]);

--- a/resin/resin/imgui/transform_gizmo.hpp
+++ b/resin/resin/imgui/transform_gizmo.hpp
@@ -9,12 +9,11 @@ namespace ImGui {  // NOLINT
 
 namespace resin {
 
-enum class GizmoMode : uint8_t { Local = 0, World };
+enum class GizmoMode : uint8_t { Local = 0, World = 1, _Count = 2 };                           // NOLINT
+enum class GizmoOperation : uint8_t { Translation = 0, Rotation = 1, Scale = 2, _Count = 3 };  // NOLINT
 
-bool TranslationGizmo(::resin::Transform& trans, const ::resin::Camera& camera, GizmoMode mode, float width,
-                      float height);
-
-bool RotationGizmo(::resin::Transform& trans, const ::resin::Camera& camera, GizmoMode mode, float width, float height);
+bool TransformGizmo(::resin::Transform& trans, const ::resin::Camera& camera, GizmoMode mode, GizmoOperation operation,
+                    float width, float height);
 
 }  // namespace resin
 

--- a/resin/resin/imgui/transform_gizmo.hpp
+++ b/resin/resin/imgui/transform_gizmo.hpp
@@ -1,0 +1,23 @@
+#ifndef RESIN_TRANSFORM_GIZMO_HPP
+#define RESIN_TRANSFORM_GIZMO_HPP
+
+#include <cstdint>
+#include <libresin/core/camera.hpp>
+#include <libresin/core/transform.hpp>
+
+namespace ImGui {  // NOLINT
+
+namespace resin {
+
+enum class GizmoMode : uint8_t { Local = 0, World };
+
+bool TranslationGizmo(::resin::Transform& trans, const ::resin::Camera& camera, GizmoMode mode, float width,
+                      float height);
+
+bool RotationGizmo(::resin::Transform& trans, const ::resin::Camera& camera, GizmoMode mode, float width, float height);
+
+}  // namespace resin
+
+}  // namespace ImGui
+
+#endif

--- a/resin/resin/imgui/viewport.cpp
+++ b/resin/resin/imgui/viewport.cpp
@@ -9,7 +9,7 @@ namespace resin {
 
 bool Viewport(::resin::Framebuffer& framebuffer, bool& resized) {
   ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
-  if (!ImGui::Begin("Viewport")) {
+  if (!ImGui::Begin("Viewport", nullptr, ImGuiWindowFlags_MenuBar)) {
     ImGui::PopStyleVar();
     return false;
   }

--- a/resin/resin/resin.cpp
+++ b/resin/resin/resin.cpp
@@ -6,7 +6,6 @@
 #include <imguizmo/ImGuizmo.h>
 #include <math.h>
 
-#include <array>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
@@ -65,7 +64,7 @@ Resin::Resin() : vertex_array_(0), vertex_buffer_(0), index_buffer_(0) {
   glm::vec3 pos = glm::vec3(0, 2, 3);
   camera_->transform.set_local_pos(pos);
   glm::vec3 direction = glm::normalize(-pos);
-  //   camera_->transform.set_local_rot(glm::quatLookAt(direction, glm::vec3(0, 1, 0)));
+  camera_->transform.set_local_rot(glm::quatLookAt(direction, glm::vec3(0, 1, 0)));
   camera_->transform.set_parent(camera_rig_);
 
   point_light_       = std::make_unique<PointLight>(glm::vec3(0.57F, 0.38F, 0.04F), glm::vec3(0.0F, 1.0F, 0.5F),
@@ -100,7 +99,6 @@ Resin::Resin() : vertex_array_(0), vertex_buffer_(0), index_buffer_(0) {
   auto& group = sdf_tree_.root().push_back_child<GroupNode>(SDFBinaryOperation::SmoothUnion);
   group.push_back_child<CubeNode>(SDFBinaryOperation::SmoothUnion).transform().set_local_pos(glm::vec3(1, 1, 0));
   group.push_back_child<CubeNode>(SDFBinaryOperation::SmoothUnion).transform().set_local_pos(glm::vec3(-1, -1, 0));
-  sdf_tree_.root().push_back_child<SphereNode>(SDFBinaryOperation::SmoothUnion);
 
   // SDF Shader
   ShaderResource frag_shader = *shader_resource_manager_.get_res(path / "test.frag");
@@ -130,7 +128,6 @@ void Resin::setup_shader() {
   shader_->set_uniform("u_farPlane", camera_->far_plane());
   shader_->set_uniform("u_ortho", camera_->is_orthographic);
   shader_->set_uniform("u_camSize", camera_->height());
-  shader_->set_uniform("u_iP", glm::inverse(camera_->proj_matrix()));
 }
 
 void Resin::run() {
@@ -278,14 +275,12 @@ void Resin::update(duration_t delta) {
   shader_->set_uniform("u_sphereMat", *sphere_mat_);
 
   shader_->set_uniform("u_camSize", camera_->height());
-  shader_->set_uniform("u_iP", glm::inverse(camera_->proj_matrix()));
   shader_->set_uniform("u_iV", camera_->inverse_view_matrix());
 
   FileDialog::instance().update();
   if (is_viewport_focused_) {
     if (update_camera_controls(*camera_, window_->native_window(), static_cast<float>(delta.count()) * 1e-9F)) {
       shader_->set_uniform("u_camSize", camera_->height());
-      shader_->set_uniform("u_iP", glm::inverse(camera_->proj_matrix()));
       shader_->set_uniform("u_iV", camera_->inverse_view_matrix());
     }
   }
@@ -373,7 +368,6 @@ void Resin::gui() {
     if (ImGui::DragFloat("Camera FOV", &fov, 0.5F, 10.0F, 140.0F, "%.2f")) {
       camera_->set_fov(fov);
       shader_->set_uniform("u_camSize", camera_->height());
-      shader_->set_uniform("u_iP", glm::inverse(camera_->proj_matrix()));
     }
     ImGui::End();
   }

--- a/resin/resin/resin.cpp
+++ b/resin/resin/resin.cpp
@@ -1,12 +1,23 @@
+#include <GLFW/glfw3.h>
 #include <imgui/imgui.h>
 #include <imgui/imgui_impl_glfw.h>
 #include <imgui/imgui_impl_opengl3.h>
 #include <imgui/imgui_internal.h>
+#include <imguizmo/ImGuizmo.h>
+#include <math.h>
 
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <format>
+#include <glm/ext/quaternion_trigonometric.hpp>
+#include <glm/ext/scalar_constants.hpp>
+#include <glm/fwd.hpp>
+#include <glm/gtc/quaternion.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <glm/matrix.hpp>
+#include <glm/trigonometric.hpp>
+#include <libresin/core/camera.hpp>
 #include <libresin/core/resources/shader_resource.hpp>
 #include <libresin/core/sdf_tree/group_node.hpp>
 #include <libresin/core/sdf_tree/primitive_node.hpp>
@@ -50,7 +61,7 @@ Resin::Resin() : vertex_array_(0), vertex_buffer_(0), index_buffer_(0) {
   glm::vec3 pos = glm::vec3(0, 2, 3);
   camera_->transform.set_local_pos(pos);
   glm::vec3 direction = glm::normalize(-pos);
-  camera_->transform.set_local_rot(glm::quatLookAt(direction, glm::vec3(0, 1, 0)));
+  //   camera_->transform.set_local_rot(glm::quatLookAt(direction, glm::vec3(0, 1, 0)));
   camera_->transform.set_parent(camera_rig_);
 
   point_light_       = std::make_unique<PointLight>(glm::vec3(0.57F, 0.38F, 0.04F), glm::vec3(0.0F, 1.0F, 0.5F),
@@ -116,6 +127,7 @@ void Resin::setup_shader() {
   shader_->set_uniform("u_farPlane", camera_->far_plane());
   shader_->set_uniform("u_ortho", camera_->is_orthographic);
   shader_->set_uniform("u_camSize", camera_->height());
+  shader_->set_uniform("u_iP", glm::inverse(camera_->proj_matrix()));
 }
 
 void Resin::run() {
@@ -172,6 +184,67 @@ void Resin::run() {
   }
 }
 
+static bool update_camera_controls(Camera& camera, GLFWwindow* window, float dt) {
+  static glm::vec2 last_mouse_pos = glm::vec2(0.0f);
+  const float sensitivity         = 0.06f;
+  const float speed               = 5.0f;
+
+  double mouse_x = NAN;
+  double mouse_y = NAN;
+  glfwGetCursorPos(window, &mouse_x, &mouse_y);
+  glm::vec2 mouse_pos   = glm::vec2(mouse_x, mouse_y);
+  glm::vec2 mouse_delta = (mouse_pos - last_mouse_pos) * sensitivity;
+  last_mouse_pos        = mouse_pos;
+
+  if (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_RIGHT) != GLFW_PRESS) {
+    glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+    return false;
+  }
+
+  glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+
+  float right   = 0.F;
+  float up      = 0.F;
+  float forward = 0.F;
+
+  // Forward/Backward
+  if (!camera.is_orthographic) {
+    if (glfwGetKey(window, GLFW_KEY_W) == GLFW_PRESS) {
+      forward += speed * dt;
+    } else if (glfwGetKey(window, GLFW_KEY_S) == GLFW_PRESS) {
+      forward -= speed * dt;
+    }
+  }
+
+  // Left/Right
+  if (glfwGetKey(window, GLFW_KEY_A) == GLFW_PRESS) {
+    right -= speed * dt;
+  } else if (glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS) {
+    right += speed * dt;
+  }
+
+  // Up/Down
+  if (glfwGetKey(window, GLFW_KEY_Q) == GLFW_PRESS) {
+    up -= speed * dt;
+  } else if (glfwGetKey(window, GLFW_KEY_E) == GLFW_PRESS) {
+    up += speed * dt;
+  }
+
+  auto pos = camera.transform.local_pos();
+  pos += camera.transform.local_front() * forward + camera.transform.local_right() * right +
+         camera.transform.local_up() * up;
+  camera.transform.set_local_pos(pos);
+
+  auto rot     = camera.transform.local_rot();
+  auto yaw     = glm::angleAxis(-mouse_delta.x * 0.03F, glm::vec3(0, 1, 0));
+  auto pitch   = glm::angleAxis(-mouse_delta.y * 0.03F, camera.transform.local_right());
+  auto new_rot = yaw * pitch * rot;
+  camera.transform.set_local_rot(new_rot);
+  // TODO(SDF-82): prevent full 360 pitch flips
+
+  return true;
+}
+
 void Resin::update(duration_t delta) {
   window_->set_title(std::format("Resin [{} FPS {} TPS] running for: {}", fps_, tps_,
                                  std::chrono::duration_cast<std::chrono::seconds>(time_)));
@@ -200,7 +273,18 @@ void Resin::update(duration_t delta) {
   shader_->set_uniform("u_cubeMat", *cube_mat_);
   shader_->set_uniform("u_sphereMat", *sphere_mat_);
 
+  shader_->set_uniform("u_camSize", camera_->height());
+  shader_->set_uniform("u_iP", glm::inverse(camera_->proj_matrix()));
+  shader_->set_uniform("u_iV", camera_->inverse_view_matrix());
+
   FileDialog::instance().update();
+  if (is_viewport_focused_) {
+    if (update_camera_controls(*camera_, window_->native_window(), static_cast<float>(delta.count()) * 1e-9F)) {
+      shader_->set_uniform("u_camSize", camera_->height());
+      shader_->set_uniform("u_iP", glm::inverse(camera_->proj_matrix()));
+      shader_->set_uniform("u_iV", camera_->inverse_view_matrix());
+    }
+  }
 }
 
 void Resin::gui() {
@@ -208,8 +292,9 @@ void Resin::gui() {
 
   bool resized = false;
   if (ImGui::resin::Viewport(*framebuffer_, resized)) {
-    auto width  = static_cast<float>(framebuffer_->width());
-    auto height = static_cast<float>(framebuffer_->height());
+    is_viewport_focused_ = ImGui::IsWindowFocused();
+    auto width           = static_cast<float>(framebuffer_->width());
+    auto height          = static_cast<float>(framebuffer_->height());
 
     if (resized) {
       camera_->set_aspect_ratio(width / height);
@@ -224,7 +309,27 @@ void Resin::gui() {
 
     ImGui::Image((ImTextureID)(intptr_t)framebuffer_->color_texture(), ImVec2(width, height), ImVec2(0, 1),  // NOLINT
                  ImVec2(1, 0));
+    if (selected_node_ && !selected_node_->expired()) {
+      auto& node = sdf_tree_.node(*selected_node_);
+      auto mat   = node.transform().local_to_world_matrix();
+
+      glm::mat4 view = camera_->view_matrix();
+      glm::mat4 proj = camera_->proj_matrix();
+
+      ImGuizmo::BeginFrame();
+      ImGuizmo::SetDrawlist();
+      ImGuizmo::SetOrthographic(camera_->is_orthographic);  // Perspective mode
+      ImGuizmo::SetRect(ImGui::GetWindowPos().x + ImGui::GetCursorStartPos().x,
+                        ImGui::GetWindowPos().y + ImGui::GetCursorStartPos().y, width, height);
+
+      ImGuizmo::Manipulate(glm::value_ptr(view), glm::value_ptr(proj), ImGuizmo::OPERATION::TRANSLATE,
+                           ImGuizmo::MODE::LOCAL, glm::value_ptr(mat));
+
+      node.transform().set_local_pos(glm::vec3(mat[3][0], mat[3][1], mat[3][2]));
+      node.mark_dirty();
+    }
   }
+
   ImGui::End();
 
   ImGui::SetNextWindowSizeConstraints(ImVec2(280.F, 200.F), ImVec2(FLT_MAX, FLT_MAX));
@@ -232,6 +337,16 @@ void Resin::gui() {
     selected_node_ = ImGui::resin::SDFTreeView(sdf_tree_, selected_node_);
   }
   ImGui::End();
+
+  if (ImGui::Begin("Camera")) {
+    float fov = camera_->fov();
+    if (ImGui::DragFloat("FOV", &fov, 0.5F, 10.0F, 140.0F, "%.2f")) {
+      camera_->set_fov(fov);
+      shader_->set_uniform("u_camSize", camera_->height());
+      shader_->set_uniform("u_iP", glm::inverse(camera_->proj_matrix()));
+    }
+    ImGui::End();
+  }
 
   ImGui::SetNextWindowSizeConstraints(ImVec2(350.F, 200.F), ImVec2(FLT_MAX, FLT_MAX));
   ImGui::Begin("[TEMP] Lights");
@@ -241,6 +356,7 @@ void Resin::gui() {
       ImGui::ColorEdit3("Light color", glm::value_ptr(directional_light_->color));
       ImGui::resin::TransformEdit(&directional_light_->transform);
       ImGui::DragFloat("Ambient impact", &directional_light_->ambient_impact, 0.01F, 0.0F, 2.0F, "%.2f");
+
       ImGui::EndTabItem();
     }
     if (ImGui::BeginTabItem("PointLight")) {
@@ -283,7 +399,7 @@ void Resin::gui() {
 
   ImGui::SetNextWindowSizeConstraints(ImVec2(350.F, 200.F), ImVec2(FLT_MAX, FLT_MAX));
   ImGui::Begin("Selection");
-  if (selected_node_.has_value()) {
+  if (selected_node_.has_value() && !selected_node_->expired()) {
     ImGui::resin::NodeEdit(sdf_tree_.node(*selected_node_));
   }
 

--- a/resin/resin/resin.cpp
+++ b/resin/resin/resin.cpp
@@ -43,7 +43,11 @@
 
 namespace resin {
 
-Resin::Resin() : vertex_array_(0), vertex_buffer_(0), index_buffer_(0) {
+Resin::Resin()
+    : vertex_array_(0),
+      vertex_buffer_(0),
+      index_buffer_(0),
+      gizmo_operation_(ImGui::resin::GizmoOperation::Translation) {
   dispatcher_.subscribe<WindowCloseEvent>(BIND_EVENT_METHOD(on_window_close));
   dispatcher_.subscribe<WindowResizeEvent>(BIND_EVENT_METHOD(on_window_resize));
   dispatcher_.subscribe<WindowTestEvent>(BIND_EVENT_METHOD(on_test));
@@ -293,7 +297,7 @@ void Resin::gui() {
   if (ImGui::resin::Viewport(*framebuffer_, resized)) {
     if (ImGui::BeginMenuBar()) {
       ImGui::Text("Local Transform:");
-      ImGui::Checkbox("##LocalCheckbox", &use_local_gimos_);
+      ImGui::Checkbox("##LocalCheckbox", &use_local_gizmos_);
 
       static constexpr resin::StringEnumMapper<ImGui::resin::GizmoOperation> kOps({
           {ImGui::resin::GizmoOperation::Translation, "Translation"},  //
@@ -305,16 +309,8 @@ void Resin::gui() {
       ImGui::SetNextItemWidth(ImGui::CalcTextSize("Translation").x + 12.0F);
       if (ImGui::BeginCombo("##OperationCombo", kOps[gizmo_operation_].data(), ImGuiComboFlags_NoArrowButton)) {
         for (const auto [current_op, name] : kOps) {
-          bool disable = selected_node_ && !selected_node_->expired() && sdf_tree_.is_group(*selected_node_) &&
-                         current_op == ImGui::resin::GizmoOperation::Scale;
-          if (disable) {
-            ImGui::BeginDisabled();
-          }
           if (ImGui::Selectable(kOps[current_op].data())) {
             gizmo_operation_ = current_op;
-          }
-          if (disable) {
-            ImGui::EndDisabled();
           }
         }
         ImGui::EndCombo();
@@ -341,14 +337,10 @@ void Resin::gui() {
     ImGui::Image((ImTextureID)(intptr_t)framebuffer_->color_texture(), ImVec2(width, height), ImVec2(0, 1),  // NOLINT
                  ImVec2(1, 0));
     if (selected_node_ && !selected_node_->expired()) {
-      if (sdf_tree_.is_group(*selected_node_) && gizmo_operation_ == ImGui::resin::GizmoOperation::Scale) {
-        gizmo_operation_ = ImGui::resin::GizmoOperation::Translation;
-      }
-
       auto& node = sdf_tree_.node(*selected_node_);
       if (ImGui::resin::TransformGizmo(
               node.transform(), *camera_,
-              use_local_gimos_ ? ImGui::resin::GizmoMode::Local : ImGui::resin::GizmoMode::World, gizmo_operation_,
+              use_local_gizmos_ ? ImGui::resin::GizmoMode::Local : ImGui::resin::GizmoMode::World, gizmo_operation_,
               width, height)) {
         node.mark_dirty();
       }

--- a/resin/resin/resin.hpp
+++ b/resin/resin/resin.hpp
@@ -75,6 +75,9 @@ class Resin {
   Transform camera_rig_;
   bool is_viewport_focused_;
 
+  bool use_local_gimos_;
+  bool show_rotation_gizmo_;
+
   bool running_   = true;
   bool minimized_ = false;
 

--- a/resin/resin/resin.hpp
+++ b/resin/resin/resin.hpp
@@ -74,9 +74,9 @@ class Resin {
   std::unique_ptr<DirectionalLight> directional_light_;
   std::unique_ptr<Material> cube_mat_, sphere_mat_;
   Transform camera_rig_;
-  bool is_viewport_focused_;
+  bool is_viewport_focused_{false};
+  bool use_local_gizmos_{false};
 
-  bool use_local_gimos_;
   ImGui::resin::GizmoOperation gizmo_operation_;
 
   bool running_   = true;

--- a/resin/resin/resin.hpp
+++ b/resin/resin/resin.hpp
@@ -15,6 +15,7 @@
 #include <resin/core/window.hpp>
 #include <resin/event/event.hpp>
 #include <resin/event/window_events.hpp>
+#include <resin/imgui/transform_gizmo.hpp>
 
 int main();
 
@@ -76,7 +77,7 @@ class Resin {
   bool is_viewport_focused_;
 
   bool use_local_gimos_;
-  bool show_rotation_gizmo_;
+  ImGui::resin::GizmoOperation gizmo_operation_;
 
   bool running_   = true;
   bool minimized_ = false;

--- a/resin/resin/resin.hpp
+++ b/resin/resin/resin.hpp
@@ -73,6 +73,7 @@ class Resin {
   std::unique_ptr<DirectionalLight> directional_light_;
   std::unique_ptr<Material> cube_mat_, sphere_mat_;
   Transform camera_rig_;
+  bool is_viewport_focused_;
 
   bool running_   = true;
   bool minimized_ = false;


### PR DESCRIPTION
I had a lot of fun writing this, but still does not feel confident about the math. I mean it works as expected but maybe there is a better way of achieving the same result with better numerical stability. For that reason please read the `transform_gizmo.cpp` and `fix_transform_and_detach` in `sdf_tree.cpp` carefully.

Apart from the gizmo I've added a temporary first person camera controller. To use it focus the viewport and press right mouse button. To move use WSADQE. The full camera controller implementation (with camera view gizmo) is a subject of [SDF-82].

Demo: 
![gizmo](https://github.com/user-attachments/assets/3ac3ed5a-2900-4c71-9e94-a0ade315340f)


[SDF-82]: https://pw-24-25-gizmokis.atlassian.net/browse/SDF-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ