### PR TITLE
[SDF-29] Add missing primitives

### DIFF
--- a/libresin/libresin/core/sdf_shader_consts.hpp
+++ b/libresin/libresin/core/sdf_shader_consts.hpp
@@ -30,18 +30,40 @@ constexpr StringEnumMapper<SDFShaderBinOp> kSDFShaderBinOpFunctionNames({
 });
 
 enum class SDFShaderPrim : uint8_t {
-  Sphere = 0,
-  Cube   = 1,
-  _Count = 2,  // NOLINT
+  Sphere          = 0,
+  Cube            = 1,
+  Torus           = 2,
+  Capsule         = 3,
+  Link            = 4,
+  Ellipsoid       = 5,
+  Pyramid         = 6,
+  Cylinder        = 7,
+  TriangularPrism = 8,
+  _Count          = 9,  // NOLINT
 };
 constexpr StringEnumMapper<SDFShaderPrim> kSDFShaderPrimFunctionNames({
-    {SDFShaderPrim::Sphere, "sdSphere"},  //
-    {SDFShaderPrim::Cube, "sdCube"}       //
+    {SDFShaderPrim::Sphere, "sdSphere"},         //
+    {SDFShaderPrim::Cube, "sdCube"},             //
+    {SDFShaderPrim::Torus, "sdTorus"},           //
+    {SDFShaderPrim::Capsule, "sdCapsule"},       //
+    {SDFShaderPrim::Link, "sdLink"},             //
+    {SDFShaderPrim::Ellipsoid, "sdEllipsoid"},   //
+    {SDFShaderPrim::Pyramid, "sdPyramid"},       //
+    {SDFShaderPrim::Cylinder, "sdCylinder"},     //
+    {SDFShaderPrim::TriangularPrism, "sdPrism"}  //
+
 });
 
 constexpr StringEnumMapper<SDFShaderPrim> kSDFShaderPrimComponentArrayNames({
-    {SDFShaderPrim::Sphere, "u_spheres"},  //
-    {SDFShaderPrim::Cube, "u_cubes"}       //
+    {SDFShaderPrim::Sphere, "u_spheres"},         //
+    {SDFShaderPrim::Cube, "u_cubes"},             //
+    {SDFShaderPrim::Torus, "u_tori"},             //
+    {SDFShaderPrim::Capsule, "u_capsules"},       //
+    {SDFShaderPrim::Link, "u_links"},             //
+    {SDFShaderPrim::Ellipsoid, "u_ellipsoids"},   //
+    {SDFShaderPrim::Pyramid, "u_pyramids"},       //
+    {SDFShaderPrim::Cylinder, "u_cylinders"},     //
+    {SDFShaderPrim::TriangularPrism, "u_prisms"}  //
 });
 
 constexpr std::string_view kSDFPrimitivesArrayName = "u_sdf_primitives";

--- a/libresin/libresin/core/sdf_tree/group_node.cpp
+++ b/libresin/libresin/core/sdf_tree/group_node.cpp
@@ -22,6 +22,20 @@ SDFTreeNode& GroupNode::push_back_primitive(SDFTreePrimitiveType type, SDFBinary
       return push_back_child<SphereNode>(bin_op);
     case SDFTreePrimitiveType::Cube:
       return push_back_child<CubeNode>(bin_op);
+    case SDFTreePrimitiveType::Torus:
+      return push_back_child<TorusNode>(bin_op);
+    case SDFTreePrimitiveType::Capsule:
+      return push_back_child<CapsuleNode>(bin_op);
+    case SDFTreePrimitiveType::Link:
+      return push_back_child<LinkNode>(bin_op);
+    case SDFTreePrimitiveType::Ellipsoid:
+      return push_back_child<EllipsoidNode>(bin_op);
+    case SDFTreePrimitiveType::Pyramid:
+      return push_back_child<PyramidNode>(bin_op);
+    case SDFTreePrimitiveType::Cylinder:
+      return push_back_child<CylinderNode>(bin_op);
+    case SDFTreePrimitiveType::TriangularPrism:
+      return push_back_child<TriangularPrismNode>(bin_op);
     case resin::SDFTreePrimitiveType::_Count:
       throw NonExhaustiveEnumException();
   }

--- a/libresin/libresin/core/sdf_tree/primitive_base_node.hpp
+++ b/libresin/libresin/core/sdf_tree/primitive_base_node.hpp
@@ -11,8 +11,15 @@ class GroupNode;
 
 using SDFTreePrimitiveType = sdf_shader_consts::SDFShaderPrim;
 constexpr StringEnumMapper<SDFTreePrimitiveType> kSDFTreePrimitiveNames({
-    {SDFTreePrimitiveType::Sphere, "Sphere"},  //
-    {SDFTreePrimitiveType::Cube, "Cube"}       //
+    {SDFTreePrimitiveType::Sphere, "Sphere"},                    //
+    {SDFTreePrimitiveType::Cube, "Cube"},                        //
+    {SDFTreePrimitiveType::Torus, "Torus"},                      //
+    {SDFTreePrimitiveType::Capsule, "Capsule"},                  //
+    {SDFTreePrimitiveType::Link, "Link"},                        //
+    {SDFTreePrimitiveType::Ellipsoid, "Ellipsoid"},              //
+    {SDFTreePrimitiveType::Pyramid, "Pyramid"},                  //
+    {SDFTreePrimitiveType::Cylinder, "Cylinder"},                //
+    {SDFTreePrimitiveType::TriangularPrism, "Triangular Prism"}  //
 });
 
 class BasePrimitiveNode;

--- a/libresin/libresin/core/sdf_tree/primitive_node.cpp
+++ b/libresin/libresin/core/sdf_tree/primitive_node.cpp
@@ -8,7 +8,7 @@ SphereNode::SphereNode(SDFTreeRegistry& tree, float _radius)
     : PrimitiveNode<SDFTreePrimitiveType::Sphere>(tree), radius(_radius) {}
 
 CubeNode::CubeNode(SDFTreeRegistry& tree, glm::vec3 _size)
-    : PrimitiveNode<SDFTreePrimitiveType::Cube>(tree), size(std::move(_size)) {}
+    : PrimitiveNode<SDFTreePrimitiveType::Cube>(tree), size(_size) {}
 
 TorusNode::TorusNode(SDFTreeRegistry& tree, float _major_radius, float _minor_radius)
     : PrimitiveNode<SDFTreePrimitiveType::Torus>(tree), major_radius(_major_radius), minor_radius(_minor_radius) {}
@@ -23,7 +23,7 @@ LinkNode::LinkNode(SDFTreeRegistry& tree, float _length, float _major_radius, fl
       minor_radius(_minor_radius) {}
 
 EllipsoidNode::EllipsoidNode(SDFTreeRegistry& tree, glm::vec3 _radii)
-    : PrimitiveNode<SDFTreePrimitiveType::Ellipsoid>(tree), radii(std::move(_radii)) {}
+    : PrimitiveNode<SDFTreePrimitiveType::Ellipsoid>(tree), radii(_radii) {}
 
 PyramidNode::PyramidNode(SDFTreeRegistry& tree, float _height)
     : PrimitiveNode<SDFTreePrimitiveType::Pyramid>(tree), height(_height) {}

--- a/libresin/libresin/core/sdf_tree/primitive_node.cpp
+++ b/libresin/libresin/core/sdf_tree/primitive_node.cpp
@@ -7,6 +7,31 @@ namespace resin {
 SphereNode::SphereNode(SDFTreeRegistry& tree, float _radius)
     : PrimitiveNode<SDFTreePrimitiveType::Sphere>(tree), radius(_radius) {}
 
-CubeNode::CubeNode(SDFTreeRegistry& tree, float _size) : PrimitiveNode<SDFTreePrimitiveType::Cube>(tree), size(_size) {}
+CubeNode::CubeNode(SDFTreeRegistry& tree, glm::vec3 _size)
+    : PrimitiveNode<SDFTreePrimitiveType::Cube>(tree), size(std::move(_size)) {}
+
+TorusNode::TorusNode(SDFTreeRegistry& tree, float _major_radius, float _minor_radius)
+    : PrimitiveNode<SDFTreePrimitiveType::Torus>(tree), major_radius(_major_radius), minor_radius(_minor_radius) {}
+
+CapsuleNode::CapsuleNode(SDFTreeRegistry& tree, float _height, float _radius)
+    : PrimitiveNode<SDFTreePrimitiveType::Capsule>(tree), height(_height), radius(_radius) {}
+
+LinkNode::LinkNode(SDFTreeRegistry& tree, float _length, float _major_radius, float _minor_radius)
+    : PrimitiveNode<SDFTreePrimitiveType::Link>(tree),
+      length(_length),
+      major_radius(_major_radius),
+      minor_radius(_minor_radius) {}
+
+EllipsoidNode::EllipsoidNode(SDFTreeRegistry& tree, glm::vec3 _radii)
+    : PrimitiveNode<SDFTreePrimitiveType::Ellipsoid>(tree), radii(std::move(_radii)) {}
+
+PyramidNode::PyramidNode(SDFTreeRegistry& tree, float _height)
+    : PrimitiveNode<SDFTreePrimitiveType::Pyramid>(tree), height(_height) {}
+
+CylinderNode::CylinderNode(SDFTreeRegistry& tree, float _height, float _radius)
+    : PrimitiveNode<SDFTreePrimitiveType::Cylinder>(tree), height(_height), radius(_radius) {}
+
+TriangularPrismNode::TriangularPrismNode(SDFTreeRegistry& tree, float _prismHeight, float _baseHeight)
+    : PrimitiveNode<SDFTreePrimitiveType::TriangularPrism>(tree), prismHeight(_prismHeight), baseHeight(_baseHeight) {}
 
 }  // namespace resin

--- a/libresin/libresin/core/sdf_tree/primitive_node.hpp
+++ b/libresin/libresin/core/sdf_tree/primitive_node.hpp
@@ -33,7 +33,7 @@ class CubeNode final : public PrimitiveNode<SDFTreePrimitiveType::Cube> {
     visitor.visit_cube(*this);
   }
 
-  explicit CubeNode(SDFTreeRegistry& tree, float _size = 1.F);
+  explicit CubeNode(SDFTreeRegistry& tree, glm::vec3 _size = glm::vec3(2.F));
 
   ~CubeNode() override = default;
 
@@ -42,7 +42,140 @@ class CubeNode final : public PrimitiveNode<SDFTreePrimitiveType::Cube> {
   }
 
  public:
-  float size;
+  glm::vec3 size;
+};
+
+class TorusNode final : public PrimitiveNode<SDFTreePrimitiveType::Torus> {
+ public:
+  inline void accept_visitor(ISDFTreeNodeVisitor& visitor) override {
+    BasePrimitiveNode::accept_visitor(visitor);
+    visitor.visit_torus(*this);
+  }
+
+  explicit TorusNode(SDFTreeRegistry& tree, float _major_radius = 1.F, float _minor_radius = 0.25F);
+
+  ~TorusNode() override = default;
+
+  [[nodiscard]] inline std::unique_ptr<SDFTreeNode> copy() override {
+    return std::make_unique<TorusNode>(tree_registry_, major_radius, minor_radius);
+  }
+
+ public:
+  float major_radius, minor_radius;
+};
+
+class CapsuleNode final : public PrimitiveNode<SDFTreePrimitiveType::Capsule> {
+ public:
+  inline void accept_visitor(ISDFTreeNodeVisitor& visitor) override {
+    BasePrimitiveNode::accept_visitor(visitor);
+    visitor.visit_capsule(*this);
+  }
+
+  explicit CapsuleNode(SDFTreeRegistry& tree, float _height = 1.F, float _radius = 0.25F);
+
+  ~CapsuleNode() override = default;
+
+  [[nodiscard]] inline std::unique_ptr<SDFTreeNode> copy() override {
+    return std::make_unique<CapsuleNode>(tree_registry_, height, radius);
+  }
+
+ public:
+  float height, radius;
+};
+
+class LinkNode final : public PrimitiveNode<SDFTreePrimitiveType::Link> {
+ public:
+  inline void accept_visitor(ISDFTreeNodeVisitor& visitor) override {
+    BasePrimitiveNode::accept_visitor(visitor);
+    visitor.visit_link(*this);
+  }
+
+  explicit LinkNode(SDFTreeRegistry& tree, float _length = 1.F, float _major_radius = 1.F, float _minor_radius = 0.25F);
+
+  ~LinkNode() override = default;
+
+  [[nodiscard]] inline std::unique_ptr<SDFTreeNode> copy() override {
+    return std::make_unique<LinkNode>(tree_registry_, length, major_radius, minor_radius);
+  }
+
+ public:
+  float length, major_radius, minor_radius;
+};
+
+class EllipsoidNode final : public PrimitiveNode<SDFTreePrimitiveType::Ellipsoid> {
+ public:
+  inline void accept_visitor(ISDFTreeNodeVisitor& visitor) override {
+    BasePrimitiveNode::accept_visitor(visitor);
+    visitor.visit_ellipsoid(*this);
+  }
+
+  explicit EllipsoidNode(SDFTreeRegistry& tree, glm::vec3 _radii = glm::vec3(1.F, 2.F, 3.F) / 3.F);
+
+  ~EllipsoidNode() override = default;
+
+  [[nodiscard]] inline std::unique_ptr<SDFTreeNode> copy() override {
+    return std::make_unique<EllipsoidNode>(tree_registry_, radii);
+  }
+
+ public:
+  glm::vec3 radii;
+};
+
+class PyramidNode final : public PrimitiveNode<SDFTreePrimitiveType::Pyramid> {
+ public:
+  inline void accept_visitor(ISDFTreeNodeVisitor& visitor) override {
+    BasePrimitiveNode::accept_visitor(visitor);
+    visitor.visit_pyramid(*this);
+  }
+
+  explicit PyramidNode(SDFTreeRegistry& tree, float _height = 1.F);
+
+  ~PyramidNode() override = default;
+
+  [[nodiscard]] inline std::unique_ptr<SDFTreeNode> copy() override {
+    return std::make_unique<PyramidNode>(tree_registry_, height);
+  }
+
+ public:
+  float height;
+};
+
+class CylinderNode final : public PrimitiveNode<SDFTreePrimitiveType::Cylinder> {
+ public:
+  inline void accept_visitor(ISDFTreeNodeVisitor& visitor) override {
+    BasePrimitiveNode::accept_visitor(visitor);
+    visitor.visit_cylinder(*this);
+  }
+
+  explicit CylinderNode(SDFTreeRegistry& tree, float _height = 1.F, float _radius = 0.25F);
+
+  ~CylinderNode() override = default;
+
+  [[nodiscard]] inline std::unique_ptr<SDFTreeNode> copy() override {
+    return std::make_unique<CylinderNode>(tree_registry_, height, radius);
+  }
+
+ public:
+  float height, radius;
+};
+
+class TriangularPrismNode final : public PrimitiveNode<SDFTreePrimitiveType::TriangularPrism> {
+ public:
+  inline void accept_visitor(ISDFTreeNodeVisitor& visitor) override {
+    BasePrimitiveNode::accept_visitor(visitor);
+    visitor.visit_prism(*this);
+  }
+
+  explicit TriangularPrismNode(SDFTreeRegistry& tree, float _prismHeight = 1.F, float _baseHeight = 0.25F);
+
+  ~TriangularPrismNode() override = default;
+
+  [[nodiscard]] inline std::unique_ptr<SDFTreeNode> copy() override {
+    return std::make_unique<TriangularPrismNode>(tree_registry_, prismHeight, prismHeight);
+  }
+
+ public:
+  float prismHeight, baseHeight;
 };
 
 }  // namespace resin

--- a/libresin/libresin/core/sdf_tree/sdf_tree_node_visitor.hpp
+++ b/libresin/libresin/core/sdf_tree/sdf_tree_node_visitor.hpp
@@ -7,13 +7,27 @@ class GroupNode;
 class BasePrimitiveNode;
 class SphereNode;
 class CubeNode;
+class TorusNode;
+class CapsuleNode;
+class LinkNode;
+class EllipsoidNode;
+class PyramidNode;
+class CylinderNode;
+class TriangularPrismNode;
 
 class ISDFTreeNodeVisitor {
  public:
-  void virtual visit_sphere(SphereNode&) {}
-  void virtual visit_cube(CubeNode&) {}
   void virtual visit_group(GroupNode&) {}
   void virtual visit_primitive(BasePrimitiveNode&) {}
+  void virtual visit_sphere(SphereNode&) {}
+  void virtual visit_cube(CubeNode&) {}
+  void virtual visit_torus(TorusNode&) {}
+  void virtual visit_capsule(CapsuleNode&) {}
+  void virtual visit_link(LinkNode&) {}
+  void virtual visit_ellipsoid(EllipsoidNode&) {}
+  void virtual visit_pyramid(PyramidNode&) {}
+  void virtual visit_cylinder(CylinderNode&) {}
+  void virtual visit_prism(TriangularPrismNode&) {}
 
   virtual ~ISDFTreeNodeVisitor() = default;
 };

--- a/libresin/libresin/core/sdf_tree/sdf_tree_registry.hpp
+++ b/libresin/libresin/core/sdf_tree/sdf_tree_registry.hpp
@@ -19,7 +19,14 @@ struct SDFTreeRegistry {
   // TODO(SDF-98): allow specifying the sizes
   SDFTreeRegistry()
       : sphere_components_registry(IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Sphere>>(100)),
-        cubes_components_registry(IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Cube>>(100)),
+        cube_components_registry(IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Cube>>(100)),
+        torus_components_registry(IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Torus>>(100)),
+        capsule_components_registry(IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Capsule>>(100)),
+        link_components_registry(IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Link>>(100)),
+        ellipsoid_components_registry(IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Ellipsoid>>(100)),
+        pyramid_components_registry(IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Pyramid>>(100)),
+        cylinder_components_registry(IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Cylinder>>(100)),
+        prism_components_registry(IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::TriangularPrism>>(100)),
         transform_component_registry(IdRegistry<Transform>(100)),
         primitives_registry(IdRegistry<BasePrimitiveNode>(100)),
         nodes_registry(IdRegistry<SDFTreeNode>(100)),
@@ -30,14 +37,35 @@ struct SDFTreeRegistry {
   }
 
   IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Sphere>> sphere_components_registry;
-  IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Cube>> cubes_components_registry;
+  IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Cube>> cube_components_registry;
+  IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Torus>> torus_components_registry;
+  IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Capsule>> capsule_components_registry;
+  IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Link>> link_components_registry;
+  IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Ellipsoid>> ellipsoid_components_registry;
+  IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Pyramid>> pyramid_components_registry;
+  IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::Cylinder>> cylinder_components_registry;
+  IdRegistry<PrimitiveNode<sdf_shader_consts::SDFShaderPrim::TriangularPrism>> prism_components_registry;
 
   template <sdf_shader_consts::SDFShaderPrim EnumType>
   constexpr IdRegistry<PrimitiveNode<EnumType>>& primitive_components_registry() {
     if constexpr (sdf_shader_consts::SDFShaderPrim::Sphere == EnumType) {
       return sphere_components_registry;
     } else if constexpr (sdf_shader_consts::SDFShaderPrim::Cube == EnumType) {
-      return cubes_components_registry;
+      return cube_components_registry;
+    } else if constexpr (sdf_shader_consts::SDFShaderPrim::Torus == EnumType) {
+      return torus_components_registry;
+    } else if constexpr (sdf_shader_consts::SDFShaderPrim::Capsule == EnumType) {
+      return capsule_components_registry;
+    } else if constexpr (sdf_shader_consts::SDFShaderPrim::Link == EnumType) {
+      return link_components_registry;
+    } else if constexpr (sdf_shader_consts::SDFShaderPrim::Ellipsoid == EnumType) {
+      return ellipsoid_components_registry;
+    } else if constexpr (sdf_shader_consts::SDFShaderPrim::Pyramid == EnumType) {
+      return pyramid_components_registry;
+    } else if constexpr (sdf_shader_consts::SDFShaderPrim::Cylinder == EnumType) {
+      return cylinder_components_registry;
+    } else if constexpr (sdf_shader_consts::SDFShaderPrim::TriangularPrism == EnumType) {
+      return prism_components_registry;
     } else {
       static_assert(false, "Unsupported registry");
     }

--- a/libresin/libresin/core/shader.cpp
+++ b/libresin/libresin/core/shader.cpp
@@ -38,6 +38,9 @@ void ShaderProgram::recompile() {
   for (auto& pair : uniform_block_bindings_) {
     glUniformBlockBinding(program_id_, pair.first, pair.second);
   }
+
+  // TEMP(SDF-131) when materials will be in UBO this won't be needed
+  uniform_locations_.clear();
 }
 
 std::optional<std::string> ShaderProgram::get_shader_status(GLuint shader, GLenum type) {

--- a/libresin/libresin/core/uniform_buffer.cpp
+++ b/libresin/libresin/core/uniform_buffer.cpp
@@ -48,4 +48,53 @@ void PrimitiveUniformBuffer::PrimitiveNodeVisitor::visit_cube(CubeNode& node) {
                   sizeof(PrimitiveNode), &ubo_node);
 }
 
+void PrimitiveUniformBuffer::PrimitiveNodeVisitor::visit_torus(TorusNode& node) {
+  PrimitiveNode ubo_node(node.transform(), glm::vec3(node.major_radius, node.minor_radius, 0));
+
+  glBufferSubData(GL_UNIFORM_BUFFER, static_cast<GLintptr>(node.primitive_id().raw() * sizeof(PrimitiveNode)),
+                  sizeof(PrimitiveNode), &ubo_node);
+}
+
+void PrimitiveUniformBuffer::PrimitiveNodeVisitor::visit_capsule(CapsuleNode& node) {
+  PrimitiveNode ubo_node(node.transform(), glm::vec3(node.height, node.radius, 0));
+
+  glBufferSubData(GL_UNIFORM_BUFFER, static_cast<GLintptr>(node.primitive_id().raw() * sizeof(PrimitiveNode)),
+                  sizeof(PrimitiveNode), &ubo_node);
+}
+
+void PrimitiveUniformBuffer::PrimitiveNodeVisitor::visit_link(LinkNode& node) {
+  PrimitiveNode ubo_node(node.transform(), glm::vec3(node.length, node.major_radius, node.minor_radius));
+
+  glBufferSubData(GL_UNIFORM_BUFFER, static_cast<GLintptr>(node.primitive_id().raw() * sizeof(PrimitiveNode)),
+                  sizeof(PrimitiveNode), &ubo_node);
+}
+
+void PrimitiveUniformBuffer::PrimitiveNodeVisitor::visit_ellipsoid(EllipsoidNode& node) {
+  PrimitiveNode ubo_node(node.transform(), node.radii);
+
+  glBufferSubData(GL_UNIFORM_BUFFER, static_cast<GLintptr>(node.primitive_id().raw() * sizeof(PrimitiveNode)),
+                  sizeof(PrimitiveNode), &ubo_node);
+}
+
+void PrimitiveUniformBuffer::PrimitiveNodeVisitor::visit_pyramid(PyramidNode& node) {
+  PrimitiveNode ubo_node(node.transform(), glm::vec3(node.height, 0, 0));
+
+  glBufferSubData(GL_UNIFORM_BUFFER, static_cast<GLintptr>(node.primitive_id().raw() * sizeof(PrimitiveNode)),
+                  sizeof(PrimitiveNode), &ubo_node);
+}
+
+void PrimitiveUniformBuffer::PrimitiveNodeVisitor::visit_cylinder(CylinderNode& node) {
+  PrimitiveNode ubo_node(node.transform(), glm::vec3(node.height, node.radius, 0));
+
+  glBufferSubData(GL_UNIFORM_BUFFER, static_cast<GLintptr>(node.primitive_id().raw() * sizeof(PrimitiveNode)),
+                  sizeof(PrimitiveNode), &ubo_node);
+}
+
+void PrimitiveUniformBuffer::PrimitiveNodeVisitor::visit_prism(TriangularPrismNode& node) {
+  PrimitiveNode ubo_node(node.transform(), glm::vec3(node.prismHeight, node.baseHeight, 0));
+
+  glBufferSubData(GL_UNIFORM_BUFFER, static_cast<GLintptr>(node.primitive_id().raw() * sizeof(PrimitiveNode)),
+                  sizeof(PrimitiveNode), &ubo_node);
+}
+
 }  // namespace resin

--- a/libresin/libresin/core/uniform_buffer.hpp
+++ b/libresin/libresin/core/uniform_buffer.hpp
@@ -61,6 +61,13 @@ class PrimitiveUniformBuffer : public UniformBuffer {
   class PrimitiveNodeVisitor : public ISDFTreeNodeVisitor {
     void visit_sphere(SphereNode& node) override;
     void visit_cube(CubeNode& node) override;
+    void visit_torus(TorusNode&) override;
+    void visit_capsule(CapsuleNode&) override;
+    void visit_link(LinkNode&) override;
+    void visit_ellipsoid(EllipsoidNode&) override;
+    void visit_pyramid(PyramidNode&) override;
+    void visit_cylinder(CylinderNode&) override;
+    void visit_prism(TriangularPrismNode&) override;
   };
 
   const size_t max_count_;

--- a/libresin/libresin/utils/json.cpp
+++ b/libresin/libresin/utils/json.cpp
@@ -84,8 +84,8 @@ void JSONSerializerSDFTreeNodeVisitor::visit_cube(CubeNode& node) {
 }
 
 void JSONSerializerSDFTreeNodeVisitor::visit_torus(TorusNode& node) {
-  json_["torus"]["major_radius"] = node.major_radius;
-  json_["torus"]["minor_radius"] = node.minor_radius;
+  json_["torus"]["majorRadius"] = node.major_radius;
+  json_["torus"]["minorRadius"] = node.minor_radius;
 }
 
 void JSONSerializerSDFTreeNodeVisitor::visit_capsule(CapsuleNode& node) {
@@ -95,8 +95,8 @@ void JSONSerializerSDFTreeNodeVisitor::visit_capsule(CapsuleNode& node) {
 
 void JSONSerializerSDFTreeNodeVisitor::visit_link(LinkNode& node) {
   json_["link"]["length"]       = node.length;
-  json_["link"]["major_radius"] = node.major_radius;
-  json_["link"]["minor_radius"] = node.minor_radius;
+  json_["link"]["majorRadius"] = node.major_radius;
+  json_["link"]["minorRadius"] = node.minor_radius;
 }
 
 void JSONSerializerSDFTreeNodeVisitor::visit_ellipsoid(EllipsoidNode& node) {
@@ -113,8 +113,8 @@ void JSONSerializerSDFTreeNodeVisitor::visit_cylinder(CylinderNode& node) {
 }
 
 void JSONSerializerSDFTreeNodeVisitor::visit_prism(TriangularPrismNode& node) {
-  json_["triangular_prism"]["prism_height"] = node.prismHeight;
-  json_["triangular_prism"]["base_height"]  = node.baseHeight;
+  json_["triangularPrism"]["prismHeight"] = node.prismHeight;
+  json_["triangularPrism"]["baseHeight"]  = node.baseHeight;
 }
 
 static void find_used_materials(
@@ -314,8 +314,8 @@ void JSONDeserializerSDFTreeNodeVisitor::visit_cube(CubeNode& node) {
 
 void JSONDeserializerSDFTreeNodeVisitor::visit_torus(TorusNode& node) {
   try {
-    node.major_radius = node_json_["torus"]["major_radius"];
-    node.minor_radius = node_json_["torus"]["minor_radius"];
+    node.major_radius = node_json_["torus"]["majorRadius"];
+    node.minor_radius = node_json_["torus"]["minorRadius"];
   } catch (...) {
     log_throw(JSONNodeDeserializationException(
         std::format("Torus definition for node with name {} is invalid.", node.name())));
@@ -335,8 +335,8 @@ void JSONDeserializerSDFTreeNodeVisitor::visit_capsule(CapsuleNode& node) {
 void JSONDeserializerSDFTreeNodeVisitor::visit_link(LinkNode& node) {
   try {
     node.length       = node_json_["link"]["length"];
-    node.major_radius = node_json_["link"]["major_radius"];
-    node.minor_radius = node_json_["link"]["minor_radius"];
+    node.major_radius = node_json_["link"]["majorRadius"];
+    node.minor_radius = node_json_["link"]["minorRadius"];
   } catch (...) {
     log_throw(JSONNodeDeserializationException(
         std::format("Link definition for node with name {} is invalid.", node.name())));
@@ -375,8 +375,8 @@ void JSONDeserializerSDFTreeNodeVisitor::visit_cylinder(CylinderNode& node) {
 
 void JSONDeserializerSDFTreeNodeVisitor::visit_prism(TriangularPrismNode& node) {
   try {
-    node.prismHeight = node_json_["triangular_prism"]["prism_height"];
-    node.baseHeight  = node_json_["triangular_prism"]["base_height"];
+    node.prismHeight = node_json_["triangularPrism"]["prismHeight"];
+    node.baseHeight  = node_json_["triangularPrism"]["baseHeight"];
   } catch (...) {
     log_throw(JSONNodeDeserializationException(
         std::format("Triangular prism definition for node with name {} is invalid.", node.name())));

--- a/libresin/libresin/utils/json.cpp
+++ b/libresin/libresin/utils/json.cpp
@@ -94,7 +94,7 @@ void JSONSerializerSDFTreeNodeVisitor::visit_capsule(CapsuleNode& node) {
 }
 
 void JSONSerializerSDFTreeNodeVisitor::visit_link(LinkNode& node) {
-  json_["link"]["length"]       = node.length;
+  json_["link"]["length"]      = node.length;
   json_["link"]["majorRadius"] = node.major_radius;
   json_["link"]["minorRadius"] = node.minor_radius;
 }

--- a/libresin/libresin/utils/json.cpp
+++ b/libresin/libresin/utils/json.cpp
@@ -75,13 +75,47 @@ void JSONSerializerSDFTreeNodeVisitor::visit_group(GroupNode& node) {
   json_["group"]["children"] = children;
 }
 
+void JSONSerializerSDFTreeNodeVisitor::visit_sphere(SphereNode& node) { json_["sphere"]["radius"] = node.radius; }
+
 void JSONSerializerSDFTreeNodeVisitor::visit_cube(CubeNode& node) {
-  json_["cube"]["size"]["x"] = node.size;
-  json_["cube"]["size"]["y"] = node.size;
-  json_["cube"]["size"]["z"] = node.size;
+  json_["cube"]["size"]["x"] = node.size.x;
+  json_["cube"]["size"]["y"] = node.size.y;
+  json_["cube"]["size"]["z"] = node.size.z;
 }
 
-void JSONSerializerSDFTreeNodeVisitor::visit_sphere(SphereNode& node) { json_["sphere"]["radius"] = node.radius; }
+void JSONSerializerSDFTreeNodeVisitor::visit_torus(TorusNode& node) {
+  json_["torus"]["major_radius"] = node.major_radius;
+  json_["torus"]["minor_radius"] = node.minor_radius;
+}
+
+void JSONSerializerSDFTreeNodeVisitor::visit_capsule(CapsuleNode& node) {
+  json_["capsule"]["height"] = node.height;
+  json_["capsule"]["radius"] = node.radius;
+}
+
+void JSONSerializerSDFTreeNodeVisitor::visit_link(LinkNode& node) {
+  json_["link"]["length"]       = node.length;
+  json_["link"]["major_radius"] = node.major_radius;
+  json_["link"]["minor_radius"] = node.minor_radius;
+}
+
+void JSONSerializerSDFTreeNodeVisitor::visit_ellipsoid(EllipsoidNode& node) {
+  json_["ellipsoid"]["radii"]["x"] = node.radii.x;
+  json_["ellipsoid"]["radii"]["y"] = node.radii.y;
+  json_["ellipsoid"]["radii"]["z"] = node.radii.z;
+}
+
+void JSONSerializerSDFTreeNodeVisitor::visit_pyramid(PyramidNode& node) { json_["pyramid"]["height"] = node.height; }
+
+void JSONSerializerSDFTreeNodeVisitor::visit_cylinder(CylinderNode& node) {
+  json_["cylinder"]["height"] = node.height;
+  json_["cylinder"]["radius"] = node.radius;
+}
+
+void JSONSerializerSDFTreeNodeVisitor::visit_prism(TriangularPrismNode& node) {
+  json_["triangular_prism"]["prism_height"] = node.prismHeight;
+  json_["triangular_prism"]["base_height"]  = node.baseHeight;
+}
 
 static void find_used_materials(
     std::unordered_set<IdView<MaterialId>, IdViewHash<MaterialId>, std::equal_to<>>& used_materials,
@@ -225,24 +259,6 @@ JSONDeserializerSDFTreeNodeVisitor::JSONDeserializerSDFTreeNodeVisitor(
     const json& node_json, const std::unordered_map<size_t, IdView<MaterialId>>& material_ids_map)
     : node_json_(node_json), material_ids_map_(material_ids_map) {}
 
-void JSONDeserializerSDFTreeNodeVisitor::visit_sphere(SphereNode& node) {
-  try {
-    node.radius = node_json_["sphere"]["radius"];
-  } catch (...) {
-    log_throw(JSONNodeDeserializationException(
-        std::format("Sphere definition for node with name {} is invalid.", node.name())));
-  }
-}
-
-void JSONDeserializerSDFTreeNodeVisitor::visit_cube(CubeNode& node) {
-  try {
-    node.size = node_json_["cube"]["size"]["x"];  // TODO(SDF-29): update json deserializer for node
-  } catch (...) {
-    log_throw(JSONNodeDeserializationException(
-        std::format("Cube definition for node with name {} is invalid.", node.name())));
-  }
-}
-
 void JSONDeserializerSDFTreeNodeVisitor::visit_group(GroupNode& node) {
   try {
     for (const auto& child_json : node_json_["group"]["children"]) {
@@ -273,6 +289,97 @@ void JSONDeserializerSDFTreeNodeVisitor::visit_group(GroupNode& node) {
     Logger::warn("JSON prefab serialization failed");
     log_throw(JSONNodeDeserializationException(
         std::format("Group definition for node with name {} is invalid.", node.name())));
+  }
+}
+
+void JSONDeserializerSDFTreeNodeVisitor::visit_sphere(SphereNode& node) {
+  try {
+    node.radius = node_json_["sphere"]["radius"];
+  } catch (...) {
+    log_throw(JSONNodeDeserializationException(
+        std::format("Sphere definition for node with name {} is invalid.", node.name())));
+  }
+}
+
+void JSONDeserializerSDFTreeNodeVisitor::visit_cube(CubeNode& node) {
+  try {
+    node.size.x = node_json_["cube"]["size"]["x"];
+    node.size.y = node_json_["cube"]["size"]["y"];
+    node.size.z = node_json_["cube"]["size"]["z"];
+  } catch (...) {
+    log_throw(JSONNodeDeserializationException(
+        std::format("Cube definition for node with name {} is invalid.", node.name())));
+  }
+}
+
+void JSONDeserializerSDFTreeNodeVisitor::visit_torus(TorusNode& node) {
+  try {
+    node.major_radius = node_json_["torus"]["major_radius"];
+    node.minor_radius = node_json_["torus"]["minor_radius"];
+  } catch (...) {
+    log_throw(JSONNodeDeserializationException(
+        std::format("Torus definition for node with name {} is invalid.", node.name())));
+  }
+}
+
+void JSONDeserializerSDFTreeNodeVisitor::visit_capsule(CapsuleNode& node) {
+  try {
+    node.height = node_json_["capsule"]["height"];
+    node.radius = node_json_["capsule"]["radius"];
+  } catch (...) {
+    log_throw(JSONNodeDeserializationException(
+        std::format("Capsule definition for node with name {} is invalid.", node.name())));
+  }
+}
+
+void JSONDeserializerSDFTreeNodeVisitor::visit_link(LinkNode& node) {
+  try {
+    node.length       = node_json_["link"]["length"];
+    node.major_radius = node_json_["link"]["major_radius"];
+    node.minor_radius = node_json_["link"]["minor_radius"];
+  } catch (...) {
+    log_throw(JSONNodeDeserializationException(
+        std::format("Link definition for node with name {} is invalid.", node.name())));
+  }
+}
+
+void JSONDeserializerSDFTreeNodeVisitor::visit_ellipsoid(EllipsoidNode& node) {
+  try {
+    node.radii.x = node_json_["ellipsoid"]["radii"]["x"];
+    node.radii.y = node_json_["ellipsoid"]["radii"]["y"];
+    node.radii.z = node_json_["ellipsoid"]["radii"]["z"];
+  } catch (...) {
+    log_throw(JSONNodeDeserializationException(
+        std::format("Ellipsoid definition for node with name {} is invalid.", node.name())));
+  }
+}
+
+void JSONDeserializerSDFTreeNodeVisitor::visit_pyramid(PyramidNode& node) {
+  try {
+    node.height = node_json_["pyramid"]["height"];
+  } catch (...) {
+    log_throw(JSONNodeDeserializationException(
+        std::format("Pyramid definition for node with name {} is invalid.", node.name())));
+  }
+}
+
+void JSONDeserializerSDFTreeNodeVisitor::visit_cylinder(CylinderNode& node) {
+  try {
+    node.height = node_json_["cylinder"]["height"];
+    node.radius = node_json_["cylinder"]["radius"];
+  } catch (...) {
+    log_throw(JSONNodeDeserializationException(
+        std::format("Cylinder definition for node with name {} is invalid.", node.name())));
+  }
+}
+
+void JSONDeserializerSDFTreeNodeVisitor::visit_prism(TriangularPrismNode& node) {
+  try {
+    node.prismHeight = node_json_["triangular_prism"]["prism_height"];
+    node.baseHeight  = node_json_["triangular_prism"]["base_height"];
+  } catch (...) {
+    log_throw(JSONNodeDeserializationException(
+        std::format("Triangular prism definition for node with name {} is invalid.", node.name())));
   }
 }
 

--- a/libresin/libresin/utils/json.hpp
+++ b/libresin/libresin/utils/json.hpp
@@ -20,15 +20,15 @@ using json = nlohmann::json;
 constexpr int kNewestResinPrefabJSONSchemaVersion = 1;
 
 constexpr StringEnumMapper<SDFTreePrimitiveType> kSDFTreePrimitiveNodesJSONNames({
-    {SDFTreePrimitiveType::Sphere, "sphere"},                    //
-    {SDFTreePrimitiveType::Cube, "cube"},                        //
-    {SDFTreePrimitiveType::Torus, "torus"},                      //
-    {SDFTreePrimitiveType::Capsule, "capsule"},                  //
-    {SDFTreePrimitiveType::Link, "link"},                        //
-    {SDFTreePrimitiveType::Ellipsoid, "ellipsoid"},              //
-    {SDFTreePrimitiveType::Pyramid, "pyramid"},                  //
-    {SDFTreePrimitiveType::Cylinder, "cylinder"},                //
-    {SDFTreePrimitiveType::TriangularPrism, "triangular_prism"}  //
+    {SDFTreePrimitiveType::Sphere, "sphere"},                   //
+    {SDFTreePrimitiveType::Cube, "cube"},                       //
+    {SDFTreePrimitiveType::Torus, "torus"},                     //
+    {SDFTreePrimitiveType::Capsule, "capsule"},                 //
+    {SDFTreePrimitiveType::Link, "link"},                       //
+    {SDFTreePrimitiveType::Ellipsoid, "ellipsoid"},             //
+    {SDFTreePrimitiveType::Pyramid, "pyramid"},                 //
+    {SDFTreePrimitiveType::Cylinder, "cylinder"},               //
+    {SDFTreePrimitiveType::TriangularPrism, "triangularPrism"}  //
 });
 
 constexpr StringEnumMapper<SDFBinaryOperation> kSDFBinaryOperationsJSONNames({

--- a/libresin/libresin/utils/json.hpp
+++ b/libresin/libresin/utils/json.hpp
@@ -20,8 +20,15 @@ using json = nlohmann::json;
 constexpr int kNewestResinPrefabJSONSchemaVersion = 1;
 
 constexpr StringEnumMapper<SDFTreePrimitiveType> kSDFTreePrimitiveNodesJSONNames({
-    {SDFTreePrimitiveType::Sphere, "sphere"},  //
-    {SDFTreePrimitiveType::Cube, "cube"}       //
+    {SDFTreePrimitiveType::Sphere, "sphere"},                    //
+    {SDFTreePrimitiveType::Cube, "cube"},                        //
+    {SDFTreePrimitiveType::Torus, "torus"},                      //
+    {SDFTreePrimitiveType::Capsule, "capsule"},                  //
+    {SDFTreePrimitiveType::Link, "link"},                        //
+    {SDFTreePrimitiveType::Ellipsoid, "ellipsoid"},              //
+    {SDFTreePrimitiveType::Pyramid, "pyramid"},                  //
+    {SDFTreePrimitiveType::Cylinder, "cylinder"},                //
+    {SDFTreePrimitiveType::TriangularPrism, "triangular_prism"}  //
 });
 
 constexpr StringEnumMapper<SDFBinaryOperation> kSDFBinaryOperationsJSONNames({
@@ -50,9 +57,16 @@ class JSONSerializerSDFTreeNodeVisitor : public ISDFTreeNodeVisitor {
  public:
   explicit JSONSerializerSDFTreeNodeVisitor(json& node_json);
 
+  void visit_group(GroupNode& node) override;
   void visit_sphere(SphereNode& node) override;
   void visit_cube(CubeNode& node) override;
-  void visit_group(GroupNode& node) override;
+  void visit_torus(TorusNode&) override;
+  void visit_capsule(CapsuleNode&) override;
+  void visit_link(LinkNode&) override;
+  void visit_ellipsoid(EllipsoidNode&) override;
+  void visit_pyramid(PyramidNode&) override;
+  void visit_cylinder(CylinderNode&) override;
+  void visit_prism(TriangularPrismNode&) override;
 
  private:
   json& json_;
@@ -82,9 +96,16 @@ class JSONDeserializerSDFTreeNodeVisitor : public ISDFTreeNodeVisitor {
   explicit JSONDeserializerSDFTreeNodeVisitor(const json& node_json,
                                               const std::unordered_map<size_t, IdView<MaterialId>>& material_ids_map);
 
+  void visit_group(GroupNode& node) override;
   void visit_sphere(SphereNode& node) override;
   void visit_cube(CubeNode& node) override;
-  void visit_group(GroupNode& node) override;
+  void visit_torus(TorusNode&) override;
+  void visit_capsule(CapsuleNode&) override;
+  void visit_link(LinkNode&) override;
+  void visit_ellipsoid(EllipsoidNode&) override;
+  void visit_pyramid(PyramidNode&) override;
+  void visit_cylinder(CylinderNode&) override;
+  void visit_prism(TriangularPrismNode&) override;
 
  private:
   const json& node_json_;

--- a/libresin/tests/glm_helper.hpp
+++ b/libresin/tests/glm_helper.hpp
@@ -55,13 +55,18 @@ template <typename T, glm::qualifier Q>
 
 // Macro for glm vector comparison.
 #define EXPECT_GLM_VEC_NEAR(expected, actual, epsilon) EXPECT_PRED_FORMAT3(AreGLMVectorsNear, expected, actual, epsilon)
+#define ASSERT_GLM_VEC_NEAR(expected, actual, epsilon) ASSERT_PRED_FORMAT3(AreGLMVectorsNear, expected, actual, epsilon)
 
 // Macro for glm matrix comparison.
 #define EXPECT_GLM_MAT_NEAR(expected, actual, epsilon) \
   EXPECT_PRED_FORMAT3(AreGLMMatricesNear, expected, actual, epsilon)
+#define ASSERT_GLM_MAT_NEAR(expected, actual, epsilon) \
+  ASSERT_PRED_FORMAT3(AreGLMMatricesNear, expected, actual, epsilon)
 
 // Macro for glm quaternion comparison.
 #define EXPECT_GLM_ROT_NEAR(expected, actual, epsilon) \
   EXPECT_PRED_FORMAT3(AreGLMQuaternionRotationsNear, expected, actual, epsilon)
+#define ASSERT_GLM_ROT_NEAR(expected, actual, epsilon) \
+  ASSERT_PRED_FORMAT3(AreGLMQuaternionRotationsNear, expected, actual, epsilon)
 
 #endif

--- a/libresin/tests/utils/json_tests.cpp
+++ b/libresin/tests/utils/json_tests.cpp
@@ -127,7 +127,7 @@ TEST_F(JSONTest, PrefabIsProperlySerializedAndDeserialized) {
   ASSERT_NO_THROW({
     auto& prim        = static_cast<resin::CubeNode&>(group2.get_child(*it));          // NOLINT
     auto& prefab_prim = static_cast<resin::CubeNode&>(prefab->get_child(*prefab_it));  // NOLINT
-    ASSERT_NEAR(prim.size, prefab_prim.size, 1e-4F);
+    ASSERT_GLM_VEC_NEAR(prim.size, prefab_prim.size, 1e-4F);
   });
 
   it++;
@@ -164,6 +164,6 @@ TEST_F(JSONTest, PrefabIsProperlySerializedAndDeserialized) {
   ASSERT_NO_THROW({
     auto& prim        = static_cast<resin::CubeNode&>(tree.node(*it));         // NOLINT
     auto& prefab_prim = static_cast<resin::CubeNode&>(tree.node(*prefab_it));  // NOLINT
-    ASSERT_NEAR(prim.size, prefab_prim.size, 1e-4F);
+    ASSERT_GLM_VEC_NEAR(prim.size, prefab_prim.size, 1e-4F);
   });
 }

--- a/resin/assets/blinn_phong.glsl
+++ b/resin/assets/blinn_phong.glsl
@@ -11,7 +11,7 @@ material material_mix(material m1, material m2, float k) {
     return material(mix(m1.albedo, m2.albedo, k), mix(m1.ka, m2.ka, k), mix(m1.kd, m2.kd, k), mix(m1.ks, m2.ks, k), mix(m1.m, m2.m, k));
 }
 
-uniform material u_sdf_materials[2];
+uniform material u_sdf_materials[9];
 
 struct attenuation {
 	float constant;

--- a/resin/assets/sdf.glsl
+++ b/resin/assets/sdf.glsl
@@ -40,8 +40,104 @@ sdf_result sdCube(vec3 pos, int node_id, int primitive_id)
     prepare(res, pos, node_id, primitive_id, 1);
 
     sdf_node prop = u_sdf_primitives[primitive_id];
-    vec3 d = abs(pos) - prop.size;
+    vec3 d = abs(pos) - 0.5*prop.size;
     res.dist = prop.scale == 0 ? u_farPlane : prop.scale * (min(max(d.x,max(d.y,d.z)),0.0) + length(max(d,0.0)));
+    return res;
+}
+
+sdf_result sdTorus(vec3 pos, int node_id, int primitive_id)
+{
+    sdf_result res;
+
+    prepare(res, pos, node_id, primitive_id, 2);
+
+    sdf_node prop = u_sdf_primitives[primitive_id];
+    vec2 d = vec2(length(pos.xz) - prop.size.x, pos.y);
+    res.dist = prop.scale == 0 ? u_farPlane : prop.scale * (length(d) - prop.size.y);
+    return res;
+}
+
+sdf_result sdCapsule(vec3 pos, int node_id, int primitive_id)
+{
+    sdf_result res;
+
+    prepare(res, pos, node_id, primitive_id, 3);
+
+    sdf_node prop = u_sdf_primitives[primitive_id];
+    vec3 d = vec3(pos.x, pos.y - clamp(pos.y, -0.5*prop.size.x, 0.5*prop.size.x), pos.z);
+    res.dist = prop.scale == 0 ? u_farPlane : prop.scale * (length(d) - prop.size.y);
+    return res;
+}
+
+sdf_result sdLink(vec3 pos, int node_id, int primitive_id)
+{
+    sdf_result res;
+
+    prepare(res, pos, node_id, primitive_id, 4);
+
+    sdf_node prop = u_sdf_primitives[primitive_id];
+    vec3 d = vec3(pos.x, max(abs(pos.y) - 0.5*prop.size.x, 0.0), pos.z);
+    res.dist = prop.scale == 0 ? u_farPlane : prop.scale * (length(vec2(length(d.xy)-prop.size.y,d.z)) - prop.size.z);
+    return res;
+}
+
+sdf_result sdEllipsoid(vec3 pos, int node_id, int primitive_id)
+{
+    sdf_result res;
+
+    prepare(res, pos, node_id, primitive_id, 5);
+
+    sdf_node prop = u_sdf_primitives[primitive_id];
+    vec2 d = vec2(length(pos/prop.size), length(pos/(prop.size*prop.size)));
+    res.dist = prop.scale == 0 ? u_farPlane : prop.scale * (d.x*(d.x-1.0)/d.y);
+    return res;
+}
+
+//https://iquilezles.org/articles/distfunctions/
+sdf_result sdPyramid(vec3 pos, int node_id, int primitive_id)
+{
+    sdf_result res;
+
+    prepare(res, pos, node_id, primitive_id, 6);
+
+    sdf_node prop = u_sdf_primitives[primitive_id];
+    float h = prop.size.x;
+    float m2 = h*h + 0.25;
+    pos.xz = abs(pos.xz);
+    pos.xz = (pos.z>pos.x) ? pos.zx : pos.xz;
+    pos.xz -= 0.5;
+    vec3 q = vec3(pos.z, h*pos.y - 0.5*pos.x, h*pos.x + 0.5*pos.y);
+    float s = max(-q.x,0.0);
+    float t = clamp((q.y-0.5*pos.z)/(m2+0.25), 0.0, 1.0);
+    float a = m2*(q.x+s)*(q.x+s) + q.y*q.y;
+    float b = m2*(q.x+0.5*t)*(q.x+0.5*t) + (q.y-m2*t)*(q.y-m2*t);
+    float d2 = min(q.y,-q.x*m2-q.y*0.5) > 0.0 ? 0.0 : min(a,b);
+    res.dist = prop.scale == 0 ? u_farPlane : prop.scale * (sqrt( (d2+q.z*q.z)/m2 ) * sign(max(q.z,-pos.y)));
+    return res;
+}
+
+sdf_result sdCylinder(vec3 pos, int node_id, int primitive_id)
+{
+    sdf_result res;
+
+    prepare(res, pos, node_id, primitive_id, 7);
+
+    sdf_node prop = u_sdf_primitives[primitive_id];
+    vec2 d = abs(vec2(pos.y,length(pos.xz))) - vec2(prop.size.x/2, prop.size.y);
+    res.dist = prop.scale == 0 ? u_farPlane : prop.scale * (min(max(d.y,d.x),0.0) + length(max(d,0.0)));
+    return res;
+}
+
+//https://iquilezles.org/articles/distfunctions/
+sdf_result sdPrism(vec3 pos, int node_id, int primitive_id)
+{
+    sdf_result res;
+
+    prepare(res, pos, node_id, primitive_id, 8);
+
+    sdf_node prop = u_sdf_primitives[primitive_id];
+    vec3 d = abs(pos);
+    res.dist = prop.scale == 0 ? u_farPlane : prop.scale * (max(d.y-prop.size.x*0.5, max(d.x*0.866025+pos.z*0.5,-pos.z)-prop.size.y*0.5));
     return res;
 }
 

--- a/resin/resin/imgui/node_edit.cpp
+++ b/resin/resin/imgui/node_edit.cpp
@@ -40,7 +40,7 @@ static void edit_op(::resin::SDFTreeNode& node) {
 
 void resin::SDFNodeEditVisitor::visit_sphere(::resin::SphereNode& node) {
   if (ImGui::BeginTabItem("Properties")) {
-    NODE_DIRTY(ImGui::DragFloat("Radius", &node.radius, 0.01F, 0.0F, 1.0F, "%.2f"));
+    NODE_DIRTY(ImGui::DragFloat("Radius", &node.radius, 0.01F, 0.0F, 2.0F, "%.2f"));
     edit_op(node);
     ImGui::EndTabItem();
   }
@@ -49,7 +49,76 @@ void resin::SDFNodeEditVisitor::visit_sphere(::resin::SphereNode& node) {
 
 void resin::SDFNodeEditVisitor::visit_cube(::resin::CubeNode& node) {
   if (ImGui::BeginTabItem("Properties")) {
-    NODE_DIRTY(ImGui::DragFloat("Size", &node.size, 0.01F, 0.0F, 1.0F, "%.2f"));
+    NODE_DIRTY(ImGui::DragFloat3("Size", glm::value_ptr(node.size), 0.01F, 0.0F, 2.0F, "%.2f"));
+    edit_op(node);
+    ImGui::EndTabItem();
+  }
+  // edit_mat_tab(node.mat);
+}
+
+void resin::SDFNodeEditVisitor::visit_torus(::resin::TorusNode& node) {
+  if (ImGui::BeginTabItem("Properties")) {
+    NODE_DIRTY(ImGui::DragFloat("Major radius", &node.major_radius, 0.01F, 0.0F, 2.0F, "%.2f"));
+    NODE_DIRTY(ImGui::DragFloat("Minor radius", &node.minor_radius, 0.01F, 0.0F, 2.0F, "%.2f"));
+    edit_op(node);
+    ImGui::EndTabItem();
+  }
+  // edit_mat_tab(node.mat);
+}
+
+void resin::SDFNodeEditVisitor::visit_capsule(::resin::CapsuleNode& node) {
+  if (ImGui::BeginTabItem("Properties")) {
+    NODE_DIRTY(ImGui::DragFloat("Height", &node.height, 0.01F, 0.0F, 2.0F, "%.2f"));
+    NODE_DIRTY(ImGui::DragFloat("Radius", &node.radius, 0.01F, 0.0F, 2.0F, "%.2f"));
+    edit_op(node);
+    ImGui::EndTabItem();
+  }
+  // edit_mat_tab(node.mat);
+}
+
+void resin::SDFNodeEditVisitor::visit_link(::resin::LinkNode& node) {
+  if (ImGui::BeginTabItem("Properties")) {
+    NODE_DIRTY(ImGui::DragFloat("Length", &node.length, 0.01F, 0.0F, 2.0F, "%.2f"));
+    NODE_DIRTY(ImGui::DragFloat("Major radius", &node.major_radius, 0.01F, 0.0F, 2.0F, "%.2f"));
+    NODE_DIRTY(ImGui::DragFloat("Minor radius", &node.minor_radius, 0.01F, 0.0F, 2.0F, "%.2f"));
+    edit_op(node);
+    ImGui::EndTabItem();
+  }
+  // edit_mat_tab(node.mat);
+}
+
+void resin::SDFNodeEditVisitor::visit_ellipsoid(::resin::EllipsoidNode& node) {
+  if (ImGui::BeginTabItem("Properties")) {
+    NODE_DIRTY(ImGui::DragFloat3("Size", glm::value_ptr(node.radii), 0.01F, 0.0F, 2.0F, "%.2f"));
+    edit_op(node);
+    ImGui::EndTabItem();
+  }
+  // edit_mat_tab(node.mat);
+}
+
+void resin::SDFNodeEditVisitor::visit_pyramid(::resin::PyramidNode& node) {
+  if (ImGui::BeginTabItem("Properties")) {
+    NODE_DIRTY(ImGui::DragFloat("Height", &node.height, 0.01F, 0.0F, 2.0F, "%.2f"));
+    edit_op(node);
+    ImGui::EndTabItem();
+  }
+  // edit_mat_tab(node.mat);
+}
+
+void resin::SDFNodeEditVisitor::visit_cylinder(::resin::CylinderNode& node) {
+  if (ImGui::BeginTabItem("Properties")) {
+    NODE_DIRTY(ImGui::DragFloat("Height", &node.height, 0.01F, 0.0F, 2.0F, "%.2f"));
+    NODE_DIRTY(ImGui::DragFloat("Radius", &node.radius, 0.01F, 0.0F, 2.0F, "%.2f"));
+    edit_op(node);
+    ImGui::EndTabItem();
+  }
+  // edit_mat_tab(node.mat);
+}
+
+void resin::SDFNodeEditVisitor::visit_prism(::resin::TriangularPrismNode& node) {
+  if (ImGui::BeginTabItem("Properties")) {
+    NODE_DIRTY(ImGui::DragFloat("Prism Height", &node.prismHeight, 0.01F, 0.0F, 2.0F, "%.2f"));
+    NODE_DIRTY(ImGui::DragFloat("Base Height", &node.baseHeight, 0.01F, 0.0F, 2.0F, "%.2f"));
     edit_op(node);
     ImGui::EndTabItem();
   }

--- a/resin/resin/imgui/node_edit.hpp
+++ b/resin/resin/imgui/node_edit.hpp
@@ -11,6 +11,13 @@ class SDFNodeEditVisitor : public ::resin::ISDFTreeNodeVisitor {
  public:
   void visit_sphere(::resin::SphereNode& node) override;
   void visit_cube(::resin::CubeNode& node) override;
+  void visit_torus(::resin::TorusNode&) override;
+  void visit_capsule(::resin::CapsuleNode&) override;
+  void visit_link(::resin::LinkNode&) override;
+  void visit_ellipsoid(::resin::EllipsoidNode&) override;
+  void visit_pyramid(::resin::PyramidNode&) override;
+  void visit_cylinder(::resin::CylinderNode&) override;
+  void visit_prism(::resin::TriangularPrismNode&) override;
 
   static constexpr ::resin::StringEnumMapper<::resin::SDFBinaryOperation> kOperationSymbol =
       ::resin::StringEnumMapper<::resin::SDFBinaryOperation>({

--- a/resin/resin/resin.cpp
+++ b/resin/resin/resin.cpp
@@ -112,8 +112,16 @@ Resin::Resin()
   directional_light_->transform.set_local_rot(glm::quatLookAt(-glm::normalize(glm::vec3(0, 2, 3)), glm::vec3(0, 1, 0)));
 
   // Setup example materials
-  cube_mat_   = std::make_unique<Material>(glm::vec3(0.96F, 0.25F, 0.25F));
-  sphere_mat_ = std::make_unique<Material>(glm::vec3(0.25F, 0.25F, 0.96F));
+  // TEMP(SDF-131): remove
+  sphere_mat_    = std::make_unique<Material>(glm::vec3(0.25F, 0.25F, 0.96F));
+  cube_mat_      = std::make_unique<Material>(glm::vec3(0.96F, 0.25F, 0.25F));
+  torus_mat_     = std::make_unique<Material>(glm::vec3(0.25F, 0.96F, 0.25F));
+  capsule_mat_   = std::make_unique<Material>(glm::vec3(0.96F, 0.96F, 0.25F));
+  link_mat_      = std::make_unique<Material>(glm::vec3(0.96F, 0.25F, 0.96F));
+  ellipsoid_mat_ = std::make_unique<Material>(glm::vec3(0.25F, 0.96F, 0.96F));
+  pyramid_mat_   = std::make_unique<Material>(glm::vec3(0.25F, 0.25F, 0.25F));
+  cylinder_mat_  = std::make_unique<Material>(glm::vec3(0.96F, 0.96F, 0.96F));
+  prism_mat_     = std::make_unique<Material>(glm::vec3(0.1F, 0.6F, 0.9F));
 
   setup_shader_uniforms();
 }
@@ -219,9 +227,16 @@ void Resin::update(duration_t delta) {
   primitive_ubo_->update_dirty(sdf_tree_);
   primitive_ubo_->unbind();
 
-  // TODO(SDF-87)
+  // TEMP(SDF-131): remove
   shader_->set_uniform("u_sdf_materials[0]", *sphere_mat_);
   shader_->set_uniform("u_sdf_materials[1]", *cube_mat_);
+  shader_->set_uniform("u_sdf_materials[2]", *torus_mat_);
+  shader_->set_uniform("u_sdf_materials[3]", *capsule_mat_);
+  shader_->set_uniform("u_sdf_materials[4]", *link_mat_);
+  shader_->set_uniform("u_sdf_materials[5]", *ellipsoid_mat_);
+  shader_->set_uniform("u_sdf_materials[6]", *pyramid_mat_);
+  shader_->set_uniform("u_sdf_materials[7]", *cylinder_mat_);
+  shader_->set_uniform("u_sdf_materials[8]", *prism_mat_);
 
   shader_->set_uniform("u_dirLight", *directional_light_);
   shader_->set_uniform("u_pointLight", *point_light_);
@@ -248,6 +263,18 @@ void Resin::render() {
     grid_shader_->bind();
     raycaster_->draw_call();
     grid_shader_->unbind();
+  }
+}
+
+// TEMP(SDF-131): remove
+void Resin::material_inspect(Material& mat, std::string_view name) {
+  if (ImGui::BeginTabItem(name.data())) {
+    ImGui::ColorEdit3("Color", glm::value_ptr(mat.albedo));
+    ImGui::DragFloat("Ambient", &mat.ambientFactor, 0.01F, 0.0F, 1.0F, "%.2f");
+    ImGui::DragFloat("Diffuse", &mat.diffuseFactor, 0.01F, 0.0F, 1.0F, "%.2f");
+    ImGui::DragFloat("Specular", &mat.specularFactor, 0.01F, 0.0F, 1.0F, "%.2f");
+    ImGui::DragFloat("Exponent", &mat.specularExponent, 0.1F, 0.0F, 100.0F, "%.1f");
+    ImGui::EndTabItem();
   }
 }
 
@@ -384,23 +411,16 @@ void Resin::gui(duration_t delta) {
 
   ImGui::Begin("[TEMP] Materials");
   if (ImGui::BeginTabBar("MaterialTabBar", ImGuiTabBarFlags_None)) {
-    // TODO(SDF-87)
-    if (ImGui::BeginTabItem("CubeMat")) {
-      ImGui::ColorEdit3("Color", glm::value_ptr(cube_mat_->albedo));
-      ImGui::DragFloat("Ambient", &cube_mat_->ambientFactor, 0.01F, 0.0F, 1.0F, "%.2f");
-      ImGui::DragFloat("Diffuse", &cube_mat_->diffuseFactor, 0.01F, 0.0F, 1.0F, "%.2f");
-      ImGui::DragFloat("Specular", &cube_mat_->specularFactor, 0.01F, 0.0F, 1.0F, "%.2f");
-      ImGui::DragFloat("Exponent", &cube_mat_->specularExponent, 0.1F, 0.0F, 100.0F, "%.1f");
-      ImGui::EndTabItem();
-    }
-    if (ImGui::BeginTabItem("SphereMat")) {
-      ImGui::ColorEdit3("Color", glm::value_ptr(sphere_mat_->albedo));
-      ImGui::DragFloat("Ambient", &sphere_mat_->ambientFactor, 0.01F, 0.0F, 1.0F, "%.2f");
-      ImGui::DragFloat("Diffuse", &sphere_mat_->diffuseFactor, 0.01F, 0.0F, 1.0F, "%.2f");
-      ImGui::DragFloat("Specular", &sphere_mat_->specularFactor, 0.01F, 0.0F, 1.0F, "%.2f");
-      ImGui::DragFloat("Exponent", &sphere_mat_->specularExponent, 0.1F, 0.0F, 100.0F, "%.1f");
-      ImGui::EndTabItem();
-    }
+    // TEMP(SDF-131): remove
+    material_inspect(*sphere_mat_, "SphereMat");
+    material_inspect(*cube_mat_, "CubeMat");
+    material_inspect(*torus_mat_, "TorusMat");
+    material_inspect(*capsule_mat_, "CapsuleMat");
+    material_inspect(*link_mat_, "LinkMat");
+    material_inspect(*ellipsoid_mat_, "EllipsoidMat");
+    material_inspect(*pyramid_mat_, "PyramidMat");
+    material_inspect(*cylinder_mat_, "CylinderMat");
+    material_inspect(*prism_mat_, "PrismMat");
     ImGui::EndTabBar();
   }
   ImGui::End();

--- a/resin/resin/resin.hpp
+++ b/resin/resin/resin.hpp
@@ -119,7 +119,10 @@ class Resin {
   std::unique_ptr<Camera> camera_;
   std::unique_ptr<PointLight> point_light_;
   std::unique_ptr<DirectionalLight> directional_light_;
-  std::unique_ptr<Material> cube_mat_, sphere_mat_;
+  // TEMP(SDF-131): remove
+  void material_inspect(Material& mat, std::string_view name);
+  std::unique_ptr<Material> sphere_mat_, cube_mat_, torus_mat_, capsule_mat_, link_mat_, ellipsoid_mat_, pyramid_mat_,
+      cylinder_mat_, prism_mat_;
 
   bool use_local_gizmos_{false};
   bool is_grid_{true};

--- a/schemas/definitions.schema.json
+++ b/schemas/definitions.schema.json
@@ -146,9 +146,146 @@
               "minimum": 0
             }
           }
+        }
+      }
+    },
+    "torus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "majorRadius",
+        "minorRadius"
+      ],
+      "properties": {
+        "majorRadius": {
+          "type": "number",
+          "minimum": 0
         },
-        "materialId": {
-          "type": "number"
+        "minorRadius": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "capsule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "height",
+        "radius"
+      ],
+      "properties": {
+        "height": {
+          "type": "number",
+          "minimum": 0
+        },
+        "radius": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "length",
+        "majorRadius",
+        "minorRadius"
+      ],
+      "properties": {
+        "length": {
+          "type": "number",
+          "minimum": 0
+        },
+        "majorRadius": {
+          "type": "number",
+          "minimum": 0
+        },
+        "minorRadius": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "ellipsoid": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "radii"
+      ],
+      "properties": {
+        "radii": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "x",
+            "y",
+            "z"
+          ],
+          "properties": {
+            "x": {
+              "type": "number",
+              "minimum": 0
+            },
+            "y": {
+              "type": "number",
+              "minimum": 0
+            },
+            "z": {
+              "type": "number",
+              "minimum": 0
+            }
+          }
+        }
+      }
+    },
+    "pyramid": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "height"
+      ],
+      "properties": {
+        "height": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "cylinder": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "height",
+        "radius"
+      ],
+      "properties": {
+        "height": {
+          "type": "number",
+          "minimum": 0
+        },
+        "radius": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "triangularPrism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "prismHeight",
+        "baseHeight"
+      ],
+      "properties": {
+        "prismHeight": {
+          "type": "number",
+          "minimum": 0
+        },
+        "baseHeight": {
+          "type": "number",
+          "minimum": 0
         }
       }
     },
@@ -212,6 +349,139 @@
         }
       ]
     },
+    "torusNode": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/nodeCommon"
+        },
+        {
+          "type": "object",
+          "required": [
+            "torus"
+          ],
+          "properties": {
+            "torus": {
+              "$ref": "#/$defs/torus"
+            }
+          }
+        }
+      ]
+    },
+    "capsuleNode": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/nodeCommon"
+        },
+        {
+          "type": "object",
+          "required": [
+            "capsule"
+          ],
+          "properties": {
+            "capsule": {
+              "$ref": "#/$defs/capsule"
+            }
+          }
+        }
+      ]
+    },
+    "linkNode": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/nodeCommon"
+        },
+        {
+          "type": "object",
+          "required": [
+            "link"
+          ],
+          "properties": {
+            "link": {
+              "$ref": "#/$defs/link"
+            }
+          }
+        }
+      ]
+    },
+    "ellipsoidNode": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/nodeCommon"
+        },
+        {
+          "type": "object",
+          "required": [
+            "ellipsoid"
+          ],
+          "properties": {
+            "ellipsoid": {
+              "$ref": "#/$defs/ellipsoid"
+            }
+          }
+        }
+      ]
+    },
+    "pyramidNode": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/nodeCommon"
+        },
+        {
+          "type": "object",
+          "required": [
+            "pyramid"
+          ],
+          "properties": {
+            "pyramid": {
+              "$ref": "#/$defs/pyramid"
+            }
+          }
+        }
+      ]
+    },
+    "cylinderNode": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/nodeCommon"
+        },
+        {
+          "type": "object",
+          "required": [
+            "cylinder"
+          ],
+          "properties": {
+            "cylinder": {
+              "$ref": "#/$defs/cylinder"
+            }
+          }
+        }
+      ]
+    },
+    "triangularPrismNode": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/nodeCommon"
+        },
+        {
+          "type": "object",
+          "required": [
+            "triangularPrism"
+          ],
+          "properties": {
+            "triangularPrism": {
+              "$ref": "#/$defs/triangularPrism"
+            }
+          }
+        }
+      ]
+    },
     "group": {
       "type": "object",
       "additionalProperties": false,
@@ -253,6 +523,27 @@
         },
         {
           "$ref": "#/$defs/cubeNode"
+        },
+        {
+          "$ref": "#/$defs/torusNode"
+        },
+        {
+          "$ref": "#/$defs/capsuleNode"
+        },
+        {
+          "$ref": "#/$defs/linkNode"
+        },
+        {
+          "$ref": "#/$defs/ellipsoidNode"
+        },
+        {
+          "$ref": "#/$defs/pyramidNode"
+        },
+        {
+          "$ref": "#/$defs/cylinderNode"
+        },
+        {
+          "$ref": "#/$defs/triangularPrismNode"
         }
       ]
     },


### PR DESCRIPTION
New primitives added:
- torus,
- capsule,
- chain link,
- ellipsoid,
- pyramid,
- cylinder,
- triangular prism.

![image](https://github.com/user-attachments/assets/e3edf863-9dd8-4737-8d51-437dbba52894)

This change involves **_a lot_** of boilerplate, so be sure to review it carefully!